### PR TITLE
Add manifest files for a pack.

### DIFF
--- a/fabric/st2.yaml
+++ b/fabric/st2.yaml
@@ -1,0 +1,6 @@
+---
+name : fabric 
+description : st2 content pack containing fabric integrations
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com

--- a/jira/st2.yaml
+++ b/jira/st2.yaml
@@ -1,0 +1,6 @@
+---
+name : jira
+description : st2 content pack containing jira integrations
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
- Manifest files(st2.yaml) are necessaryto recognize a folder as an st2 pack.
- For now very minimal meta information carried in the manifest as mostly a
  placeholder and suggestion as to what can be supplied. This is expected to
  have some clear requirements soon. For now the manifest content is informational
  and not parsed.
