### PR TITLE
Add Travis CI config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,11 @@
+language: python
+python: 2.7
+os:
+  - linux
+
+script:
+  - make all
+
+notifications:
+  email:
+    - eng@stackstorm.com


### PR DESCRIPTION
This branch adds Travis CI config file.

For now, "make all" target just validates JSON meta-data files (https://github.com/StackStorm/st2contrib/commit/b9fa31fa0c78df7c9604d95a3d25ab71bae1f636), but we should also fix all the flake8 violations and update it to also run flake8 on all the Python files).
