### PR TITLE
Fix libcloud pack requirements

### DIFF
--- a/packs/libcloud/requirements.txt
+++ b/packs/libcloud/requirements.txt
@@ -1,1 +1,1 @@
-libcloud
+apache-libcloud>=0.15.1


### PR DESCRIPTION
The package is named apache-libcloud and not libcloud.
