### PR TITLE
Add initial CHANGES.md file to every pack directory

### DIFF
--- a/packs/aws/CHANGES.md
+++ b/packs/aws/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/docker/CHANGES.md
+++ b/packs/docker/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/git/CHANGES.md
+++ b/packs/git/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/jira/CHANGES.md
+++ b/packs/jira/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/libcloud/CHANGES.md
+++ b/packs/libcloud/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/nagios/CHANGES.md
+++ b/packs/nagios/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/openstack/CHANGES.md
+++ b/packs/openstack/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/puppet/CHANGES.md
+++ b/packs/puppet/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/sensu/CHANGES.md
+++ b/packs/sensu/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release

--- a/packs/twilio/CHANGES.md
+++ b/packs/twilio/CHANGES.md
@@ -1,0 +1,5 @@
+# Changelog
+
+## v0.1.0
+
+* Initial release


### PR DESCRIPTION
This branch adds initial `CHANGES.md` file to every pack directory.

I believe we should maintain per-pack changes file which allows users to easily see what's new / what has changed between versions.

Actual versioning and version management is a different story for which I will start a discussion.
