### PR TITLE
JIRA sensor yaml should specify payload_schema

### DIFF
--- a/packs/jira/sensors/jira_sensor.yaml
+++ b/packs/jira/sensors/jira_sensor.yaml
@@ -7,11 +7,20 @@
     -
       name: "issues_tracker"
       description: "Trigger which indicates that a new issue has been created"
-      payload_info:
-        - "project"
-        - "issue_name"
-        - "issue_url"
-        - "created"
-        - "assignee"
-        - "fix_versions"
-        - "issue_type"
+      payload_schema:
+        type: "object"
+        properties:
+          project:
+            type: "string"
+          issue_name:
+            type: "string"
+          issue_url:
+            type: "string"
+          created:
+            type: "string"
+          assignee:
+            type: "string"
+          fix_versions:
+            type: "string"
+          issue_type:
+            type: "string"


### PR DESCRIPTION
Closes StackStorm/st2contrib#63

JIRA sensor yaml was using deprecated payload_info. This was causing
registration errors. It now uses payload_schema.
