### PR TITLE
Modified diag_loadavg to post to slack

### DIFF
--- a/packs/linux/actions/diag_loadavg.chain.yaml
+++ b/packs/linux/actions/diag_loadavg.chain.yaml
@@ -42,24 +42,18 @@
       params: 
         hosts: "{{hostname}}"
         pids: "{{d_state_processes[hostname].stderr}} {{r_state_processes[hostname].stderr}}"
-      on-success: "to_file"
+      on-success: "slack_say"
       on-failure: "email_escalation"
     - 
-      name: "stormbot_say"
-      ref: "core.stormbot_say"
+      name: "slack_say"
+      ref: "slack.post_message"
       params: 
-        source: "ACTION"
-        name: "load_alert_diagnostics"
-        msg: "'\nLOAD: {{check_load[hostname].stdout}}\nState D: {{d_state_processes[hostname].stdout}}\nState R:{{r_state_processes[hostname].stdout}}'"
+        channel: "#thunderdome"
+        message: "'\n\tLOAD: {{check_load[hostname].stdout}}\n\tState D: {{d_state_processes[hostname].stdout}}\n\tState R:{{r_state_processes[hostname].stdout}}\n\tNetstat: {{netstat[hostname].stdout}}\n\tlsof: {{lsof[hostname].stdout}}'"
       on-failure: "email_escalation"
     - 
       name: "email_escalation"
       ref: "core.local"
       params: 
         cmd: "echo 'ST2 Workflow Failure\tThe load_alert workflow has failed\t{{__results}}' >> /tmp/chain && echo 'Output written to file'"
-    - 
-      name: "to_file"
-      ref: "core.local"
-      params: 
-        cmd: "echo 'ST2 Workflow Results\n\tThe load_alert workflow results:\n\n{{__results}}' >> /tmp/chain && echo 'Output written to file'"
   default: "check_load"


### PR DESCRIPTION
This modifies the diag_loadavg workflow to post to Slack instead of writing the output to a file.
