### PR TITLE
Fixing integer params

### DIFF
--- a/packs/aws/actions/ec2_run_instances.yaml
+++ b/packs/aws/actions/ec2_run_instances.yaml
@@ -38,7 +38,7 @@ parameters:
   instance_profile_name:
     type: string
   instance_type:
-    default: m1.small
+    default: t2.medium
     type: string
   kernel_id:
     type: string
@@ -46,10 +46,10 @@ parameters:
     type: string
   max_count:
     default: 1
-    type: string
+    type: integer
   min_count:
     default: 1
-    type: string
+    type: integer
   module_path:
     default: boto.ec2.connection
     immutable: true

--- a/packs/aws/actions/r53_zone_add_record.yaml
+++ b/packs/aws/actions/r53_zone_add_record.yaml
@@ -28,7 +28,7 @@ parameters:
     type: string
   ttl:
     default: 60
-    type: string
+    type: integer
   value:
     required: true
     type: string

--- a/packs/aws/actions/r53_zone_find_records.yaml
+++ b/packs/aws/actions/r53_zone_find_records.yaml
@@ -16,7 +16,7 @@ parameters:
     type: string
   desired:
     default: 1
-    type: string
+    type: integer
   identifier:
     type: string
   module_path:


### PR DESCRIPTION
Actions were failing to run due to a type issue with certain params.  This correctly types the integer params.
