### PR TITLE
Pwh/dig action

### DIFF
--- a/packs/linux/actions/dig.py
+++ b/packs/linux/actions/dig.py
@@ -1,0 +1,29 @@
+#! /usr/bin/python
+
+import subprocess, random, re
+from st2actions.runners.pythonrunner import Action
+
+class DigAction(Action):
+
+    def run(self,rand,count,nameserver,hostname,queryopts):
+        opt_list = []
+        output = []
+        nameserver = '@' + nameserver
+        cmd_args = ['dig', nameserver]
+
+        if re.search(',',queryopts):
+            opt_list = queryopts.split(',')
+        else:
+            opt_list.append(queryopts)
+        for k,v in enumerate(opt_list):
+            cmd_args.append('+' + v)
+
+        cmd_args.append(hostname)
+        result_list = filter(None, subprocess.Popen(cmd_args,stderr = subprocess.PIPE, stdout = subprocess.PIPE).communicate()[0].split('\n'))
+        if int(count) > len(result_list) or count <= 0:
+            count = len(result_list)
+
+        output = result_list[0:count]
+        if rand is True:
+            random.shuffle(output)
+        return output

--- a/packs/linux/actions/dig.yaml
+++ b/packs/linux/actions/dig.yaml
@@ -1,7 +1,7 @@
 description: 'Dig action'
 enabled: true
 entry_point: dig.py
-name: dig_short
+name: dig
 parameters:
   queryopts:
     default: 'short'

--- a/packs/linux/actions/dig.yaml
+++ b/packs/linux/actions/dig.yaml
@@ -1,0 +1,21 @@
+description: 'Dig action'
+enabled: true
+entry_point: dig.py
+name: dig_short
+parameters:
+  queryopts:
+    default: 'short'
+    type: string
+  rand:
+    default: False
+    type: boolean
+  nameserver:
+    default: '127.0.0.1'
+    type: string
+  hostname:
+    required: true
+    type: string
+  count:
+    type: integer
+    default: 0
+runner_type: run-python


### PR DESCRIPTION
This adds a dig action.

The supported parameters are:
* nameserver - the nameserver to query.  Defaults to 127.0.0.1
* hostname - the hostname to lookup
* queryopts - Dig query options.  Defaults to short
    * See http://linux.die.net/man/1/dig
* count - number of results to return
* rand - this randomizes the returned list