### PR TITLE
Add new FileWatch sensor which monitors files for activity (new lines)

### DIFF
--- a/packs/linux/README.md
+++ b/packs/linux/README.md
@@ -2,6 +2,29 @@
 
 This pack contains actions for commonly used Linux commands and tools.
 
+## Configuration
+
+* ``file_watch_sensor.file_paths`` - A list of paths to files to monitor.
+
+## Sensors
+
+### FileWatchSensor
+
+This sensor monitors specified files for new new lines. Once a new line is
+detected, a trigger is emitted.
+
+### linux.file_watch.line trigger
+
+Example trigger payload:
+
+```json
+{
+    "file_path": "/var/log/auth.log",
+    "file_name": "auth.log",
+    "line": "Jan 18 13:38:15 vagrant-ubuntu-trusty-64 sudo:  vagrant : TTY=pts/3 ; PWD=/data/stanley ; USER=root ; COMMAND=/bin/ls"
+}
+```
+
 ## Actions
 
 * ``vmstat`` - Wrapper around the `vmstat` command.

--- a/packs/linux/config.yaml
+++ b/packs/linux/config.yaml
@@ -1,0 +1,2 @@
+file_watch_sensor:
+  file_paths:

--- a/packs/linux/requirements.txt
+++ b/packs/linux/requirements.txt
@@ -1,0 +1,3 @@
+# used by file watcher sensor
+pyinotify>=0.9.5,<=0.10
+-e git+https://github.com/Kami/logshipper.git@stackstorm_patched#egg=logshipper

--- a/packs/linux/sensors/file_watch_sensor.py
+++ b/packs/linux/sensors/file_watch_sensor.py
@@ -1,0 +1,50 @@
+import os
+
+from logshipper.tail import Tail
+
+from st2reactor.sensor.base import Sensor
+
+
+class FileWatchSensor(Sensor):
+    def __init__(self, sensor_service, config=None):
+        super(FileWatchSensor, self).__init__(sensor_service=sensor_service,
+                                              config=config)
+        self._config = self._config['file_watch_sensor']
+
+        self._file_paths = self._config.get('file_paths', [])
+        self._trigger_ref = 'linux.file_watch.line'
+        self._tail = None
+
+    def setup(self):
+        if not self._file_paths:
+            raise ValueError('No file_paths configured to monitor')
+
+        self._tail = Tail(filenames=self._file_paths)
+        self._tail.handler = self._handle_line
+        self._tail.should_run = True
+
+    def run(self):
+        self._tail.run()
+
+    def cleanup(self):
+        if self._tail:
+            self._tail.should_run = False
+            self._tail.notifier.stop()
+
+    def add_trigger(self, trigger):
+        pass
+
+    def update_trigger(self, trigger):
+        pass
+
+    def remove_trigger(self, trigger):
+        pass
+
+    def _handle_line(self, file_path, line):
+        trigger = self._trigger_ref
+        payload = {
+            'file_path': file_path,
+            'file_name': os.path.basename(file_path),
+            'line': line
+        }
+        self._sensor_service.dispatch(trigger=trigger, payload=payload)

--- a/packs/linux/sensors/file_watch_sensor.py
+++ b/packs/linux/sensors/file_watch_sensor.py
@@ -29,7 +29,11 @@ class FileWatchSensor(Sensor):
     def cleanup(self):
         if self._tail:
             self._tail.should_run = False
-            self._tail.notifier.stop()
+
+            try:
+                self._tail.notifier.stop()
+            except Exception:
+                pass
 
     def add_trigger(self, trigger):
         pass

--- a/packs/linux/sensors/file_watch_sensor.yaml
+++ b/packs/linux/sensors/file_watch_sensor.yaml
@@ -1,0 +1,17 @@
+---
+  class_name: "FileWatchSensor"
+  entry_point: "file_watch_sensor.py"
+  description: "Sensor which monitors files for new lines"
+  trigger_types:
+    -
+      name: "file_watch.line"
+      description: "Trigger which indicates a new line has been detected"
+      payload_schema:
+        type: "object"
+        properties:
+          file_path:
+            type: "object"
+          file_name:
+            type: "object"
+          line:
+            type: "string"


### PR DESCRIPTION
This sensor monitors files for activity and emits a trigger every time a new line is detected.

This sensor allows users to do many cool things:

* Ship log lines to logging services (loggly, logstash, splunk, etc.)
* Implement tools such as fail2ban on top of StackStorm
* ...

Underneath it depends on logshipper which uses wrapped version of pyinotify which cooperates with eventlet.

I've put the sensor in a linux pack, but if you think it belongs in a separate pack and you have a suggestion for a pack name, let me know.