### PR TITLE
live hosts

### DIFF
--- a/packs/get_live_hosts/README.md
+++ b/packs/get_live_hosts/README.md
@@ -1,0 +1,5 @@
+#Scan Live Hosts
+This pack scans live hosts on a given network using nmap. It returns total number of live hosts and a list of IP's of the live hosts on a network.
+
+#Usage:
+st2 run get_live_hosts.get_live_hosts network= # give the network(a subnet) for listing the live hosts

--- a/packs/get_live_hosts/actions/get_live_hosts.py
+++ b/packs/get_live_hosts/actions/get_live_hosts.py
@@ -1,0 +1,26 @@
+import nmap
+from st2actions.runners.pythonrunner import Action
+
+
+
+class check_live_hosts(Action):  
+
+  def run(self, network):
+    host_list = []
+    res = nmap.PortScanner()
+    print "Starting Network Discovery...."
+    lh = res.scan(network, arguments='-sP -n')
+    print "Number of Live Hosts on network : ",lh['nmap']['scanstats']['uphosts']
+    print "Live Hosts : "
+    for ip in res.all_hosts():
+      host_list.append(ip)
+    return host_list
+ 
+
+
+if __name__ == "__main__":
+  check_up = check_live_hosts()
+  check_up.run()
+
+
+

--- a/packs/get_live_hosts/actions/get_live_hosts.py
+++ b/packs/get_live_hosts/actions/get_live_hosts.py
@@ -3,7 +3,7 @@ from st2actions.runners.pythonrunner import Action
 
 
 
-class check_live_hosts(Action):  
+class CheckLiveHosts(Action):  
 
   def run(self, network):
     host_list = []

--- a/packs/get_live_hosts/actions/get_live_hosts.yaml
+++ b/packs/get_live_hosts/actions/get_live_hosts.yaml
@@ -1,0 +1,11 @@
+name: get_live_hosts
+runner_type: run-python
+description: List all hosts on a given Network
+enabled: true
+entry_point: get_live_hosts.py
+parameters:
+  network:
+    type: string
+    description: "Network to query live hosts "
+    required: true
+


### PR DESCRIPTION
This pack scans live hosts on a given network using nmap. It returns total number of live hosts and a list of IP's of the live hosts on a network. It takes one argument that is the network, which is mandatory
Usage:
st2 run get_live_hosts.get_live_hosts network=<1.1.1.1/1> # give the network(a subnet) for listing the live hosts