### PR TITLE
Fix a get_one in the API error caused by a duplicated slash in the event handler

### DIFF
--- a/packs/nagios/etc/st2service_handler.py
+++ b/packs/nagios/etc/st2service_handler.py
@@ -57,7 +57,7 @@ def _create_trigger_type():
 def _register_with_st2():
     global REGISTERED_WITH_ST2
     try:
-        url = _get_st2_triggers_url() + '/' + ST2_TRIGGERTYPE_REF
+        url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
         # sys.stdout.write('GET: %s\n' % url)
         get_resp = requests.get(url)
 

--- a/packs/sensu/etc/st2_handler.py
+++ b/packs/sensu/etc/st2_handler.py
@@ -50,7 +50,7 @@ def _create_trigger_type():
 def _register_with_st2():
     global REGISTERED_WITH_ST2
     try:
-        url = _get_st2_triggers_url() + '/' + ST2_TRIGGERTYPE_REF
+        url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
         # sys.stdout.write('GET: %s\n' % url)
         get_resp = requests.get(url)
 


### PR DESCRIPTION
Spotted by cleavoy on IRC.

```
2015-01-27 15:55:33,155 ERROR [-] API call failed.
Traceback (most recent call last):
  File "/data/stanley/st2common/st2common/models/api/base.py", line 156, in callfunction
    result = f(*args, **kwargs)
TypeError: get_one() takes exactly 2 arguments (3 given)
127.0.0.1 - - [27/Jan/2015 15:55:33] "GET /v1/triggertypes//sensu.event_handler HTTP/1.1" 500 485 0.004312
(9868) accepted ('127.0.0.1', 44373)
```

Also, not a fan that we have a same script duplicated in two directories :P