### PR TITLE
Unformat domains in Message Data

### DIFF
--- a/packs/slack/README.md
+++ b/packs/slack/README.md
@@ -16,6 +16,9 @@ Pack which allows integration with [Slack](https://slack.com/) service.
   is used.
 * ``sensor.token`` - Authentication token used to authenticate against Real
   Time Messaging API.
+* ``sensor.strip_formatting`` - By default, Slack automatically parses URLs, images,
+  channels, and usernames. This option removes formatting and only returns the raw
+  data from the client (URL only today)
 
 ### Obtaining a Webhook URL
 

--- a/packs/slack/config.yaml
+++ b/packs/slack/config.yaml
@@ -8,3 +8,4 @@ post_message_action:
 # Used for Slack sensor
 sensor:
   token: ""
+  strip_formatting: false

--- a/packs/slack/sensors/slack_sensor.py
+++ b/packs/slack/sensors/slack_sensor.py
@@ -1,4 +1,5 @@
 import json
+import re
 
 import eventlet
 from slackclient import SlackClient
@@ -24,6 +25,7 @@ class SlackSensor(PollingSensor):
                                           poll_interval=poll_interval)
         self._logger = self._sensor_service.get_logger(__name__)
         self._token = self._config['sensor']['token']
+
         self._handlers = {
             'message': self._handle_message,
         }
@@ -106,7 +108,7 @@ class SlackSensor(PollingSensor):
                 'topic': channel_info['topic']['value'],
             },
             'timestamp': int(float(data['ts'])),
-            'text': data['text']
+            'text': re.sub("<http.*[|](.*)>", "\\1", data['text']) # Removes any server-side formatting for domains only
         }
         self._sensor_service.dispatch(trigger=trigger, payload=payload)
 

--- a/packs/slack/sensors/slack_sensor.py
+++ b/packs/slack/sensors/slack_sensor.py
@@ -25,11 +25,7 @@ class SlackSensor(PollingSensor):
                                           poll_interval=poll_interval)
         self._logger = self._sensor_service.get_logger(__name__)
         self._token = self._config['sensor']['token']
-        if 'strip_formatting' in self._config['sensor']:
-            self._strip_formatting = self._config['sensor']['strip_formatting']
-        else:
-            self._strip_formatting = False
-
+        self._strip_formatting = self._config['sensor'].get('strip_formatting', False)
         self._handlers = {
             'message': self._handle_message,
         }


### PR DESCRIPTION
Quick and dirty regex replace of message formatting given by Slack. When typing in a domain (stackstorm.com), slack formats this to `<http://stackstorm.com|stackstorm.com>`. Not sure where is the best way to filter this out, but for now here it is.