### PR TITLE
Increased wait sleep from 3 seconds to 10 seconds to avoid race condition

### DIFF
--- a/packs/aws/actions/lib/action.py
+++ b/packs/aws/actions/lib/action.py
@@ -44,7 +44,7 @@ class BaseAction(Action):
     def wait_for_state(self, instance_id, state):
         state_list = {}
         obj = self.ec2_connect()
-        time.sleep(3)
+        time.sleep(10)
         for instance in obj.get_only_instances([instance_id,]):
             try:
                 current_state = instance.update()


### PR DESCRIPTION
If a workflow creates a vm and calls this action it needs to sleep briefly to avoid a race condition where the API does not return the instance information.