### PR TITLE
Updating Endpoint for DripStat alerts

### DIFF
--- a/packs/dripstat/sensors/dripstat_alert_sensor.py
+++ b/packs/dripstat/sensors/dripstat_alert_sensor.py
@@ -68,10 +68,10 @@ class DripstatAlertSensor(PollingSensor):
         self._sensor_service.dispatch(trigger=trigger, payload=payload)
 
     def _get_last_alert_timestamp(self, app):
-        self._last_alert_timestamp = self._sensor_service.get_value("%s.last_alert_timestamp" % app)
+        last_alert_timestamp = self._sensor_service.get_value("%s.last_alert_timestamp" % app)
 
-        if self._last_alert_timestamp:
-            return self._last_alert_timestamp
+        if last_alert_timestamp:
+            return int(last_alert_timestamp)
         else:
             return 0
 

--- a/packs/dripstat/sensors/dripstat_alert_sensor.py
+++ b/packs/dripstat/sensors/dripstat_alert_sensor.py
@@ -23,6 +23,7 @@ class DripstatAlertSensor(PollingSensor):
                                                   config=config,
                                                   poll_interval=poll_interval)
         self._trigger_ref = 'dripstat.alert'
+        self._log = self._sensor_service.get_logger(__name__)
 
     def setup(self):
         self._api_key = self._config['api_key']
@@ -30,9 +31,12 @@ class DripstatAlertSensor(PollingSensor):
 
     def poll(self):
         for application in self._applications:
-            alerts = self._api_request(endpoint='/alerts', params={'appId': application['id']})
+            alerts = self._api_request(endpoint='/activeAlerts', params={'appId': application['id']})
             for alert in alerts:
-                self._dispatch_trigger_for_alert(application=application['name'], alert=alert)
+                last_alert_timestamp = self._get_last_alert_timestamp(application['name'])
+                if alert['startedAt'] > last_alert_timestamp:
+                    self._set_last_alert_timestamp(application['name'], alert['startedAt'])
+                    self._dispatch_trigger_for_alert(application=application['name'], alert=alert)
 
     def cleanup(self):
         pass
@@ -62,3 +66,14 @@ class DripstatAlertSensor(PollingSensor):
             'jvm_host': alert['jvmHost']
         }
         self._sensor_service.dispatch(trigger=trigger, payload=payload)
+
+    def _get_last_alert_timestamp(self, app):
+        self._last_alert_timestamp = self._sensor_service.get_value("%s.last_alert_timestamp" % app)
+
+        if self._last_alert_timestamp:
+            return self._last_alert_timestamp
+        else:
+            return 0
+
+    def _set_last_alert_timestamp(self, app, timestamp):
+        self._sensor_service.set_value(name='%s.last_alert_timestamp' % app, value=str(timestamp))


### PR DESCRIPTION
This commit changes the endpoint for DripStat to leverage the
stateless endpoint `/activeAlerts`. Alert timestamps are stored
in the internal K/V store on a per application basis to prevent
accidental replay of alerts into the system.