### PR TITLE
[RFC] RSS pack with RSS sensor (first sensor which utilizes trigger with parameters)

### DIFF
--- a/packs/rss/README.md
+++ b/packs/rss/README.md
@@ -1,5 +1,7 @@
 # RSS Integration Pack
 
+This pack contains integrations for RSS / Atom feeds.
+
 ## Sensors
 
 ### RSSSensor
@@ -8,15 +10,21 @@ This sensor periodically polls RSS / Atom feed for new entries and once a new
 entry is detected, a trigger is emitted.
 
 By default the sensor tries to filter out duplicated entries by using the entry
-publish timestamp - a trigger is only emitted for entries with a timestamp
-which is larger than the one we have last seen.
+"published at" / "updated at" timestamp - a trigger is only emitted for entries
+with a timestamp which is larger than the one we have last seen.
 
 Keep in mind that this approach is not perfect and it's a compromise between
-duplicated triggers and potentially missing some entries. Some blog post new
-entries with a timestamp in the past - if timestamp based filtering is enabled,
-those entries will be skipped.
+duplicated triggers and potentially missing some entries. Some blogs publish
+new entries with a timestamp in the past - if timestamp based filtering is
+enabled, those entries will be skipped / missed.
 
-TODO - this is sensor with parameters document how to configure it via cli
+Supported feed standards:
+
+* Atom 0.3
+* Atom 1.0
+* RSS 1.0
+* RSS 2.0
+* RSS 2.0 with namespaces
 
 #### rss.entry trigger
 
@@ -34,6 +42,8 @@ Example trigger payload:
         "title": "Rackspace::Solve San Francisco",
         "author": "annie",
         "published_at_timestamp": 1425549639,
+        "updated_at_timestamp": null,
+        "url": "http://stackstorm.com/2015/03/05/rackspacesolve/?utm_source=rss&utm_medium=rss&utm_campaign=rackspacesolve",
         "summary": "<p>March 4, 2015 San Francisco, CA Visit StackStorm at Boo [&#8230;]</p>\\n<p>The post <a href=\"http://stackstorm.com/2015/03/05/rackspacesolve/\" rel=\"nofollow\">Rackspace::Solve San Francisco</a> appeared first on <a href=\"http://stackstorm.com\" rel=\"nofollow\">StackStorm</a>.</p>",
         "content": "<p>March 4, 2015<br />\\nSan Francisco, CA<br />\\nVisit StackStorm at Booth #20!</p>\\n<p>During Rackspace::Solve, Rackspace will demonstrate the use of StackStorm to automate autoscaling and continuous integration and delivery pipelines, showing how StackStorm can integrate and then automate heterogeneous environments.</p>\\n<p><img alt=\"Solve\" class=\"alignnone size-medium wp-image-2661\" height=\"48\" src=\"http://stackstorm.com/wp/wp-content/uploads/2015/02/Solve-300x48.jpg\" width=\"300\" /></p>\\n<p><a href=\"http://rackspacesolve.com/sanfrancisco.html\" target=\"_blank\">EVENT WEBSITE</a></p><p>The post <a href=\"http://stackstorm.com/2015/03/05/rackspacesolve/\" rel=\"nofollow\">Rackspace::Solve San Francisco</a> appeared first on <a href=\"http://stackstorm.com\" rel=\"nofollow\">StackStorm</a>.</p>",
         "content_raw": "March 4, 2015\\nSan Francisco, CA\\nVisit StackStorm at Booth #20!\\nDuring Rackspace::Solve, Rackspace will demonstrate the use of StackStorm to automate autoscaling and continuous integration and delivery pipelines, showing how StackStorm can integrate and then automate heterogeneous environments.\\n\\nEVENT WEBSITEThe post Rackspace::Solve San Francisco appeared first on StackStorm."

--- a/packs/rss/config.yaml
+++ b/packs/rss/config.yaml
@@ -1,2 +1,2 @@
 sensor:
-  use_published_at_filtering: true
+  use_timestamp_filtering: true

--- a/packs/rss/pack.yaml
+++ b/packs/rss/pack.yaml
@@ -1,0 +1,11 @@
+---
+name : rss
+description : st2 content pack containing rss / atom integrations
+keywords:
+  - rss
+  - atom
+  - feeds
+  - blogs
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com

--- a/packs/rss/sensors/rss_sensor.py
+++ b/packs/rss/sensors/rss_sensor.py
@@ -46,6 +46,8 @@ class RSSSensor(PollingSensor):
     def poll(self):
         feed_urls = self._feed_urls.keys()
 
+        self._logger.info('Processing %s feeds' % (len(feed_urls)))
+
         for feed_url in feed_urls:
             self._logger.info('Processing feed: %s' % (feed_url))
             processed_entries = self._process_feed(feed_url=feed_url)

--- a/packs/rss/sensors/rss_sensor.py
+++ b/packs/rss/sensors/rss_sensor.py
@@ -84,6 +84,7 @@ class RSSSensor(PollingSensor):
         self._logger.info('Removed feed: %s', feed_url)
 
     def _process_feed(self, feed_url):
+        # TODO: Also use etags and last-modified to reduce unncessary downloads
         try:
             parsed = feedparser.parse(feed_url)
         except Exception:
@@ -179,6 +180,7 @@ class RSSSensor(PollingSensor):
 
         entry_title = entry.get('title', None)
         entry_author = entry.get('author', None)
+        entry_url = entry.get('link', None)
         entry_published_at = entry.get('published_parsed', None)
         entry_updated_at = entry.get('updated_parsed', None)
         entry_summary = entry.get('summary', None)
@@ -209,6 +211,7 @@ class RSSSensor(PollingSensor):
             'entry': {
                 'title': entry_title,
                 'author': entry_author,
+                'url': entry_url,
                 'published_at_timestamp': entry_published_at,
                 'updated_at_timestamp': entry_updated_at,
                 'summary': entry_summary,

--- a/packs/rss/sensors/rss_sensor.py
+++ b/packs/rss/sensors/rss_sensor.py
@@ -11,7 +11,7 @@ __all__ = [
 ]
 
 
-class MLStripper(HTMLParser):
+class HTMLStripper(HTMLParser):
     def __init__(self):
         self.reset()
         self.fed = []
@@ -195,7 +195,7 @@ class RSSSensor(PollingSensor):
         if entry_content:
             entry_content = entry_content[0].get('value', None)
 
-            stripper = MLStripper()
+            stripper = HTMLStripper()
             stripper.feed(entry_content)
             entry_content_raw = stripper.get_data()
         else:

--- a/packs/rss/sensors/rss_sensor.yaml
+++ b/packs/rss/sensors/rss_sensor.yaml
@@ -2,7 +2,7 @@
   class_name: "RSSSensor"
   entry_point: "rss_sensor.py"
   description: "Sensor which monitors RSS / Atom feed for new entries"
-  poll_interval: 15
+  poll_interval: 60
   trigger_types:
     -
       name: "feed"


### PR DESCRIPTION
This pull request adds a new RSS sensor which monitors RSS / Atom feeds for new entries.

This is also a first sensor outside of StackStorm core (timer and webhook trigger) which utilizes trigger parameters (yay, achievement unlocked!). Being a first such sensor means the are some issues.

Right now it's hard to configure this sensor - only way to do it is to create a rule. Creating a rule to create a corresponding `TriggerDB` object makes some sense for built-in triggers such as webhook and timer, but it makes little sense for custom triggers utilized by a sensor. This also ties a bit into the thing we talked about yesterday - when the events flow into the system, there is no expectation of something happening. Requiring a user to create a rule to configure a trigger with parameters kinda breaks this promise... Another "problem" with rules is that those triggers with parameters are never deleted. This is not a big issue for webhooks and timers, but it's an issue for sensors.

To make custom sensors easier to configure we should add a CLI command which allows user to create `TriggerDB` objects for `TriggerTypeDB` with parameters. Sadly, to make things confusing we already have `st2 trigger <action>` set commands, but those commands actually operate on `TriggerTypeDB` and not `TriggerDB` objects (sad panda).

Any suggestions for what the CLI command name should be? The best I can come up with is `st2 trigger create-with-parameters`. An alternative would be to rename `trigger` to `trigger-type`, but when we would also need to do the same with sensors (sensor -> sensor-type).

While working and testing this sensor I used cURL to create / configure a `TriggerDB` object.

`feed_trigger.json`

``` json
{
    "pack": "rss",
    "name": "stackstorm.feed",
    "type": "rss.feed",
    "parameters": {
      "url": "http://stackstorm.com/feed/"
    }
}
```

``` bash
curl -X POST -H "Content-Type: application/json" "http://127.0.0.1:9101/v1/triggers" -d @feed_trigger.json
```
## Open questions / TODO
- How should the CLI command for creating triggers look like? See above for more info.
- We should update sensor wrapper to only call trigger handler methods (add_trigger, update_trigger, remove_trigger) for triggers with parameters. See https://github.com/StackStorm/st2contrib/pull/158#discussion_r26893132 for more info
- Update other sensors where it makes sense to utilize trigger parameters instead of a config (git, file watch, twitter, etc.). This should be a separate PR of course.
