### PR TITLE
Clean up old API keys

### DIFF
--- a/packs/rackspace/config.yaml
+++ b/packs/rackspace/config.yaml
@@ -1,5 +1,5 @@
 ---
-  username: jfryman
-  api_key: ca8295b12b80496abf08c7cad21c7997
+  username: ""
+  api_key: ""
   region: IAD
   debug: false


### PR DESCRIPTION
These API keys have long been invalidated, but doesn't quite match the other pattern we have with other packs (blank attributes to demonstrate schema).

So, this PR removes these old keys to reduce confusion.