### PR TITLE
[st2] Add new kv.set_object and kv.get_object action

### DIFF
--- a/packs/st2/README.md
+++ b/packs/st2/README.md
@@ -1,13 +1,24 @@
 # StackStorm Integration Pack
 
-The super-meta package! This integration allows integration with StackStorm. 
+The super-meta package! This integration allows integration with StackStorm.
 
-Requires StackStorm <= `v0.8.0`
+Requires StackStorm >= `v0.8.0`
 
 ## Configuration:
 
-* `base_url` - Base URL for the StackStorm API server endpoints (i.e. http://localhost). If only the base URL is provided, the client will assume default ports for the API servers are used. If any of the API server URL is provided, it will override the base URL and default port.
+* `base_url` - Base URL for the StackStorm API server endpoints (i.e.
+  ``http://localhost``). If only the base URL is provided, the client will
+  assume default ports for the API servers are used. If any of the API server
+  URL is provided, it will override the base URL and default port.
 
 ## Actions
 
-* `kvstore` - Manipulate the key/value datastore (create/update/delete)
+* ``kv.get`` - Retrieve string value from a datastore.
+* ``kv.set`` - Store string value in a datastore.
+* ``kv.grep`` - Find datastore items which name matches the provided query.
+* ``kv.delete`` - Delete item from a datastore.
+
+* ``kv.get_object`` - Deserialize and retrieve JSON serialized object from a
+  datastore.
+* ``kv.set_object`` - Serialize and store object in a datastore. Note: object
+  is serialized as JSON.

--- a/packs/st2/actions/kv_get_object.py
+++ b/packs/st2/actions/kv_get_object.py
@@ -1,0 +1,18 @@
+import json
+
+from lib.action import St2BaseAction
+
+__all__ = [
+    'St2KVPGetObjectAction'
+]
+
+
+class St2KVPGetObjectAction(St2BaseAction):
+    def run(self, key):
+        _key = self.client.keys.get_by_name(key)
+
+        if _key:
+            deserialized_value = json.loads(_key.value)
+            return deserialized_value
+        else:
+            return False

--- a/packs/st2/actions/kv_get_object.yaml
+++ b/packs/st2/actions/kv_get_object.yaml
@@ -1,0 +1,10 @@
+---
+name: 'kv.get_object'
+enabled: true
+description: 'Deserialize and retrieve JSON serialized object from a datastore'
+runner_type: run-python
+entry_point: kv_get_object.py
+parameters:
+  key:
+    required: True
+    type: string

--- a/packs/st2/actions/kv_set_object.py
+++ b/packs/st2/actions/kv_set_object.py
@@ -1,0 +1,20 @@
+import json
+
+from lib.action import St2BaseAction
+
+__all__ = [
+    'St2KVPSetObjectAction'
+]
+
+
+class St2KVPSetObjectAction(St2BaseAction):
+    def run(self, key, value):
+        serialized_value = json.dumps(value)
+        kvp = self._kvp(name=key, value=serialized_value)
+        kvp.id = key
+        update = self.client.keys.update(kvp)
+        response = {
+            'key': key,
+            'value': value
+        }
+        return response

--- a/packs/st2/actions/kv_set_object.yaml
+++ b/packs/st2/actions/kv_set_object.yaml
@@ -1,0 +1,13 @@
+---
+name: 'kv.set_object'
+enabled: true
+description: 'Serialize and store object in a datastore'
+runner_type: run-python
+entry_point: kv_set_object.py
+parameters:
+  key:
+    required: True
+    type: string
+  value:
+    required: True
+    type: object


### PR DESCRIPTION
This pull request adds new actions which allow users to store and retrieve objects from a datastore.

Internally, those objects are serialized as JSON.

```bash
st2 run st2.kv.set_object key=keyo value='{"foo": "bar"}'
...
id: 551825cd0640fd35173960e7
status: succeeded
result: 
{
    "result": {
        "key": "keyo", 
        "value": {
            "foo": "bar"
        }
    }, 
    "exit_code": 0, 
    "stderr": "", 
    "stdout": ""
}

st2 run st2.kv.get key=keyo
...
id: 551826170640fd35173960eb
status: succeeded
result: 
{
    "result": "{"foo": "bar"}", 
    "exit_code": 0, 
    "stderr": "", 
    "stdout": ""
}

st2 run st2.kv.get_object key=keyo
...
id: 551826010640fd35173960e9
status: succeeded
result: 
{
    "result": {
        "foo": "bar"
    }, 
    "exit_code": 0, 
    "stderr": "", 
    "stdout": ""
}
```