### PR TITLE
Do not expect name profile info in Slack sensor

### DIFF
--- a/packs/slack/sensors/slack_sensor.py
+++ b/packs/slack/sensors/slack_sensor.py
@@ -25,7 +25,8 @@ class SlackSensor(PollingSensor):
                                           poll_interval=poll_interval)
         self._logger = self._sensor_service.get_logger(__name__)
         self._token = self._config['sensor']['token']
-        self._strip_formatting = self._config['sensor'].get('strip_formatting', False)
+        self._strip_formatting = self._config['sensor'].get('strip_formatting',
+                                                            False)
         self._handlers = {
             'message': self._handle_message,
         }

--- a/packs/slack/sensors/slack_sensor.py
+++ b/packs/slack/sensors/slack_sensor.py
@@ -103,9 +103,12 @@ class SlackSensor(PollingSensor):
             'user': {
                 'id': user_info['id'],
                 'name': user_info['name'],
-                'first_name': user_info['profile']['first_name'],
-                'last_name': user_info['profile']['last_name'],
-                'real_name': user_info['profile']['real_name'],
+                'first_name': user_info['profile'].get('first_name',
+                                                       'Unknown'),
+                'last_name': user_info['profile'].get('last_name',
+                                                      'Unknown'),
+                'real_name': user_info['profile'].get('real_name',
+                                                      'Unknown'),
                 'is_admin': user_info['is_admin'],
                 'is_owner': user_info['is_owner']
             },


### PR DESCRIPTION
`first_name`, `last_name`, and `real_name` do not always exist for every
Slack user (bots maybe?). Expecting these values causes the sensor to
crash with a `KeyError`. This replaces them with 'Unknown' if they are not
found which allows the sensor to continue running.