### PR TITLE
Update Dripstat class name to less confusing name

### DIFF
--- a/packs/dripstat/sensors/dripstat_alert_sensor.yaml
+++ b/packs/dripstat/sensors/dripstat_alert_sensor.yaml
@@ -1,5 +1,5 @@
 ---
-  class_name: "DripstatAlertSensor"
+  class_name: "dripstat"
   entry_point: "dripstat_alert_sensor.py"
   description: "Sensor which monitors Dripstat API for active alerts"
   poll_interval: 30


### PR DESCRIPTION
This commit changes the class name to `dripstat`, which allows a user to reference this trigger by a much shorter, consumable name.