### PR TITLE
Add git.get_latest_commit action

### DIFF
--- a/packs/git/actions/get_latest_commit.yaml
+++ b/packs/git/actions/get_latest_commit.yaml
@@ -1,0 +1,19 @@
+---
+name: get_latest_commit
+runner_type: run-remote
+description: "Retrieve SHA of the latest commit for the provided branch."
+enabled: true
+entry_point: ""
+parameters:
+  repo_path:
+    type: string
+    description: Path to the directory containg the git repository.
+    required: true
+  branch:
+    type: string
+    description: Branch / ref to retrieve the latest commit for.
+    default: master
+    required: true
+  cmd:
+    default: "cd {{ repo_path }} && git rev-parse {{ branch }}"
+    immutable: true


### PR DESCRIPTION
This action retrieves SHA of the latest commit in the provided branch / ref.