### PR TITLE
RFR - Add auth headers to st2 API calls

### DIFF
--- a/packs/nagios/README.md
+++ b/packs/nagios/README.md
@@ -1,6 +1,6 @@
 ## Nagios integration
 
-To integrate Nagios with st2, we will need to add a nagios event handler which POSTs a HTTP webbhook to st2. 
+To integrate Nagios with st2, we will need to add a nagios event handler which POSTs a HTTP webbhook to st2.
 
 ## Nagios event handler
 
@@ -8,20 +8,9 @@ The event handler script is available in [etc/st2service_handler.py](etc/st2serv
 
 ## Configuring the event handler
 
-The event handler needs to know the host and webhook port of st2 HTTP server. 
-ST2_HOST and ST2_WEBHOOKS_PORT are the parameters that need to be changed.
-
-```
-# ST2 configuration
-ST2_HOST = '172.31.39.97'
-ST2_WEBHOOKS_PORT = '6000'
-```
-
-If st2 API service is configured differently than default, change the ST2_API_PORT to appropriate setting. 
-
 The event handler tries to register a trigger type first before sending any
 notifications to st2. This trigger type is then referenced in st2 rules. See
-[rules/](rules/) for examples. 
+[rules/](rules/) for examples.
 
 ## Installing the event handler
 
@@ -36,6 +25,8 @@ notifications to st2. This trigger type is then referenced in st2 rules. See
     ```
     chmod +x /usr/local/nagios/libexec/st2service_handler.py
     ```
+4. Handlers require a configuration file (See [etc/config.yaml](etc/config.yaml)) containing
+st2 credentials, st2 API URL and st2 auth URL.
 
 
 

--- a/packs/nagios/etc/config.yaml
+++ b/packs/nagios/etc/config.yaml
@@ -1,0 +1,5 @@
+---
+  st2_username: "testu"
+  st2_password: ""
+  st2_api_base_url: "http://localhost:9101/v1"
+  st2_auth_base_url: "http://localhost:9100"

--- a/packs/nagios/etc/st2service_handler.py
+++ b/packs/nagios/etc/st2service_handler.py
@@ -7,6 +7,7 @@ except ImportError:
     import json
 import os
 import sys
+from urlparse import urljoin
 
 try:
     import requests
@@ -76,7 +77,7 @@ def _create_trigger_type():
 
 
 def _get_auth_url():
-    return '%s/%s' % (ST2_AUTH_BASE_URL, ST2_AUTH_PATH)
+    return urljoin(ST2_AUTH_BASE_URL, ST2_AUTH_PATH)
 
 
 def _get_auth_token():
@@ -94,7 +95,7 @@ def _get_auth_token():
 def _register_with_st2():
     global REGISTERED_WITH_ST2
     try:
-        url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
+        url = urljoin(_get_st2_triggers_url(), ST2_TRIGGERTYPE_REF)
         # sys.stdout.write('GET: %s\n' % url)
         if not ST2_AUTH_TOKEN:
             _get_auth_token()
@@ -117,12 +118,12 @@ def _register_with_st2():
 
 
 def _get_st2_triggers_url():
-    url = '%s/%s' % (ST2_API_BASE_URL, ST2_TRIGGERS_PATH)
+    url = urljoin(ST2_API_BASE_URL, ST2_TRIGGERS_PATH)
     return url
 
 
 def _get_st2_webhooks_url():
-    url = '%s/%s' % (ST2_API_BASE_URL, ST2_WEBHOOKS_PATH)
+    url = urljoin(ST2_API_BASE_URL, ST2_WEBHOOKS_PATH)
     return url
 
 

--- a/packs/nagios/etc/st2service_handler.py
+++ b/packs/nagios/etc/st2service_handler.py
@@ -8,8 +8,15 @@ except ImportError:
 import os
 import sys
 
-import requests
-import yaml
+try:
+    import requests
+except ImportError:
+    raise ImportError('Missing dependency requests. Do ``pip install requests``.')
+
+try:
+    import yaml
+except ImportError:
+    raise ImportError('Missing dependency pyyaml. Do ``pip install pyyaml``.')
 
 # ST2 configuration
 ST2_CONFIG_FILE = './config.yaml'

--- a/packs/nagios/etc/st2service_handler.py
+++ b/packs/nagios/etc/st2service_handler.py
@@ -12,6 +12,9 @@ import urlparse
 # ST2 configuration
 ST2_HOST = 'localhost'
 ST2_API_PORT = '9101'
+# Generate an auth token using st2 CLI with a large TTL.
+# http://docs.stackstorm.com/latest/authentication.html#testing
+ST2_AUTH_TOKEN = 'DUMMY'
 
 ST2_WEBHOOKS_PATH = '/v1/webhooks/st2/'
 ST2_TRIGGERS_PATH = '/v1/triggertypes/'
@@ -59,7 +62,7 @@ def _register_with_st2():
     try:
         url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
         # sys.stdout.write('GET: %s\n' % url)
-        get_resp = requests.get(url)
+        get_resp = requests.get(url, headers={'X-Auth-Token': ST2_AUTH_TOKEN})
 
         if get_resp.status_code != httplib.OK:
             _create_trigger_type()
@@ -89,6 +92,7 @@ def _post_event_to_st2(url, body):
     headers = {}
     headers['X-ST2-Integration'] = 'nagios.'
     headers['Content-Type'] = 'application/json; charset=utf-8'
+    headers['X-Auth-Token'] = ST2_AUTH_TOKEN
     try:
         # sys.stdout.write('POST: url: %s, body: %s\n' % (url, body))
         r = requests.post(url, data=json.dumps(body), headers=headers)

--- a/packs/sensu/etc/config.yaml
+++ b/packs/sensu/etc/config.yaml
@@ -1,0 +1,5 @@
+---
+  st2_username: "testu"
+  st2_password: ""
+  st2_api_base_url: "http://localhost:9101/v1"
+  st2_auth_base_url: "http://localhost:9100"

--- a/packs/sensu/etc/st2_handler.py
+++ b/packs/sensu/etc/st2_handler.py
@@ -7,6 +7,7 @@ except ImportError:
     import json
 import os
 import sys
+from urlparse import urljoin
 
 try:
     import requests
@@ -69,7 +70,7 @@ def _create_trigger_type():
 
 
 def _get_auth_url():
-    return '%s/%s' % (ST2_AUTH_BASE_URL, ST2_AUTH_PATH)
+    return urljoin(ST2_AUTH_BASE_URL, ST2_AUTH_PATH)
 
 
 def _get_auth_token():
@@ -87,7 +88,7 @@ def _get_auth_token():
 def _register_with_st2():
     global REGISTERED_WITH_ST2
     try:
-        url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
+        url = urljoin(_get_st2_triggers_url(), ST2_TRIGGERTYPE_REF)
         # sys.stdout.write('GET: %s\n' % url)
         if not ST2_AUTH_TOKEN:
             _get_auth_token()
@@ -110,12 +111,12 @@ def _register_with_st2():
 
 
 def _get_st2_triggers_url():
-    url = '%s/%s' % (ST2_API_BASE_URL, ST2_TRIGGERS_PATH)
+    url = urljoin(ST2_API_BASE_URL, ST2_TRIGGERS_PATH)
     return url
 
 
 def _get_st2_webhooks_url():
-    url = '%s/%s' % (ST2_API_BASE_URL, ST2_WEBHOOKS_PATH)
+    url = urljoin(ST2_API_BASE_URL, ST2_WEBHOOKS_PATH)
     return url
 
 

--- a/packs/sensu/etc/st2_handler.py
+++ b/packs/sensu/etc/st2_handler.py
@@ -8,8 +8,15 @@ except ImportError:
 import os
 import sys
 
-import requests
-import yaml
+try:
+    import requests
+except ImportError:
+    raise ImportError('Missing dependency "requests". Do ``pip install requests``.')
+
+try:
+    import yaml
+except ImportError:
+    raise ImportError('Missing dependency "pyyaml". Do ``pip install pyyaml``.')
 
 # ST2 configuration
 ST2_CONFIG_FILE = './config.yaml'

--- a/packs/sensu/etc/st2_handler.py
+++ b/packs/sensu/etc/st2_handler.py
@@ -5,19 +5,24 @@ try:
     import simplejson as json
 except ImportError:
     import json
-import requests
+import os
 import sys
-import urlparse
+
+import requests
+import yaml
 
 # ST2 configuration
-ST2_HOST = 'localhost'
-ST2_API_PORT = '9101'
-# Generate an auth token using st2 CLI with a large TTL.
-# http://docs.stackstorm.com/latest/authentication.html#testing
-ST2_AUTH_TOKEN = 'DUMMY'
+ST2_CONFIG_FILE = './config.yml'
 
-ST2_WEBHOOKS_PATH = '/v1/webhooks/st2/'
-ST2_TRIGGERS_PATH = '/v1/triggertypes/'
+ST2_API_BASE_URL = 'http://localhost:9101/v1'
+ST2_AUTH_BASE_URL = 'http://localhost:9100'
+ST2_USERNAME = None
+ST2_PASSWORD = None
+ST2_AUTH_TOKEN = None
+
+ST2_AUTH_PATH = 'tokens'
+ST2_WEBHOOKS_PATH = 'webhooks/st2/'
+ST2_TRIGGERS_PATH = 'triggertypes/'
 ST2_TRIGGERTYPE_PACK = 'sensu'
 ST2_TRIGGERTYPE_NAME = 'event_handler'
 ST2_TRIGGERTYPE_REF = '.'.join([ST2_TRIGGERTYPE_PACK, ST2_TRIGGERTYPE_NAME])
@@ -50,11 +55,24 @@ def _create_trigger_type():
             sys.stdout.write('Registered trigger type with st2.\n')
 
 
+def _get_auth_url():
+    return '%s/%s' % (ST2_AUTH_BASE_URL, ST2_AUTH_PATH)
+
+
+def _get_auth_token():
+    global ST2_AUTH_TOKEN
+    auth_url = _get_auth_url()
+    resp = requests.post(auth_url, {'ttl': 5 * 60}, auth=(ST2_USERNAME, ST2_PASSWORD))
+    ST2_AUTH_TOKEN = resp.json()['token']
+
+
 def _register_with_st2():
     global REGISTERED_WITH_ST2
     try:
         url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
         # sys.stdout.write('GET: %s\n' % url)
+        if not ST2_AUTH_TOKEN:
+            _get_auth_token()
         get_resp = requests.get(url, headers={'X-Auth-Token': ST2_AUTH_TOKEN})
 
         if get_resp.status_code != httplib.OK:
@@ -70,14 +88,12 @@ def _register_with_st2():
 
 
 def _get_st2_triggers_url():
-    url = urlparse.urlunparse(('http', ST2_HOST + ':' + ST2_API_PORT, ST2_TRIGGERS_PATH,
-                              None, None, None))
+    url = '%s/%s' % (ST2_API_BASE_URL, ST2_TRIGGERS_PATH)
     return url
 
 
 def _get_st2_webhooks_url():
-    url = urlparse.urlunparse(('http',  ST2_HOST + ':' + ST2_API_PORT, ST2_WEBHOOKS_PATH,
-                               None, None, None))
+    url = '%s/%s' % (ST2_API_BASE_URL, ST2_WEBHOOKS_PATH)
     return url
 
 
@@ -109,6 +125,17 @@ def main(args):
 
 if __name__ == '__main__':
     try:
+        if not os.path.exists(ST2_CONFIG_FILE):
+            print('Configuration file not found. Exiting.')
+            sys.exit(1)
+
+        with open(ST2_CONFIG_FILE) as f:
+            config = yaml.safe_load(f)
+            ST2_USERNAME = config['st2_username']
+            ST2_PASSWORD = config['st2_password']
+            ST2_API_BASE_URL = config['st2_api_base_url']
+            ST2_AUTH_BASE_URL = config['st2_auth_base_url']
+
         if not REGISTERED_WITH_ST2:
             _register_with_st2()
     except:

--- a/packs/sensu/etc/st2_handler.py
+++ b/packs/sensu/etc/st2_handler.py
@@ -12,6 +12,9 @@ import urlparse
 # ST2 configuration
 ST2_HOST = 'localhost'
 ST2_API_PORT = '9101'
+# Generate an auth token using st2 CLI with a large TTL.
+# http://docs.stackstorm.com/latest/authentication.html#testing
+ST2_AUTH_TOKEN = 'DUMMY'
 
 ST2_WEBHOOKS_PATH = '/v1/webhooks/st2/'
 ST2_TRIGGERS_PATH = '/v1/triggertypes/'
@@ -52,7 +55,7 @@ def _register_with_st2():
     try:
         url = _get_st2_triggers_url() + ST2_TRIGGERTYPE_REF
         # sys.stdout.write('GET: %s\n' % url)
-        get_resp = requests.get(url)
+        get_resp = requests.get(url, headers={'X-Auth-Token': ST2_AUTH_TOKEN})
 
         if get_resp.status_code != httplib.OK:
             _create_trigger_type()
@@ -82,6 +85,7 @@ def _post_event_to_st2(url, body):
     headers = {}
     headers['X-ST2-Integration'] = 'sensu.'
     headers['Content-Type'] = 'application/json; charset=utf-8'
+    headers['X-Auth-Token'] = ST2_AUTH_TOKEN
     try:
         sys.stdout.write('POST: url: %s, body: %s\n' % (url, body))
         r = requests.post(url, data=json.dumps(body), headers=headers)


### PR DESCRIPTION
With 0.9 release of st2, API endpoints could have authentication turned on. Therefore, nagios and sensu handlers need to use auth headers. This PR adds the header. 

An auth token for st2 can be generated using the st2 CLI. 
http://docs.stackstorm.com/latest/authentication.html#testing

TODO:

* [X] - Test the handler.   
* [X] - https://github.com/StackStorm/st2/pull/1412