### PR TITLE
Add Use Case example to Twitter pack readme [skip ci]

### DIFF
--- a/packs/twitter/README.md
+++ b/packs/twitter/README.md
@@ -2,6 +2,9 @@
 
 Pack which allows integration with Twitter.
 
+## Use cases
+* [HOWTO: Broadcast Twitter mentions about your Company to Slack channel](http://stackstorm.com/2014/12/22/monitor-twitter-and-fire-automations-based-on-twitter-keywords-using-stackstorm/)
+
 ## Configuration
 
 * ``consumer_key`` - Twitter API consumer key.


### PR DESCRIPTION
I found @Kami article describing how to use Twitter pack with Slack http://stackstorm.com/2014/12/22/monitor-twitter-and-fire-automations-based-on-twitter-keywords-using-stackstorm/ extremely useful.

Have no idea if you have any strict rules about documentation (maybe those readmes are parsed and then reused somewhere else), but I think this HowTo link should be definitely here.
