### PR TITLE
WIP: Docker build image action fixes

### DIFF
--- a/packs/docker/actions/lib/docker_wrapper.py
+++ b/packs/docker/actions/lib/docker_wrapper.py
@@ -2,6 +2,10 @@ import sys
 import traceback
 
 from requests.packages.urllib3.exceptions import ReadTimeoutError
+try:
+    import simplejson as json
+except ImportError:
+    import json
 import six
 import docker
 
@@ -51,6 +55,7 @@ class DockerWrapper(object):
                 try:
                     json_output = six.advance_iterator(result)
                 except ReadTimeoutError:
+                    json_output = json.dumps({'status': 'Read timed out.'})
                     continue
         except StopIteration:
             pass


### PR DESCRIPTION
- Print complete traceback on exceptions for better visibility.
- JSON output from docker daemon is inconsistent depending on whether
  a base image is already existing or is being downloaded. You can either
  get {'stream': 'some message'} or {'status': 'STATUS', other fields...}.
  So this action now prints the entire JSON output.
- While using chunked transfer (stream=True), sometimes we get a ReadTimeoutError.
  In most cases, it is temporary because docker daemon is loaded. So
  we just ignore the ReadTimeoutError and retry. Note this is not ideal
  but as a client there is little we could do.
