### PR TITLE
Update script which runs pylint on a pack to also install pack Python dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,13 +3,13 @@ python: 2.7
 sudo: false
 os:
   - linux
-
+env:
+  global:
+    - "PIP_DOWNLOAD_CACHE=$HOME/.pip-cache"
 install:
   - pip install -r requirements-dev.txt
-
 script:
   - make all
-
 notifications:
   email:
     - eng@stackstorm.com

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,9 @@ os:
 env:
   global:
     - "PIP_DOWNLOAD_CACHE=$HOME/.pip-cache"
+cache:
+  directories:
+    - $HOME/.pip-cache/
 install:
   - pip install -r requirements-dev.txt
 script:

--- a/packs/gpg/actions/import_keys.py
+++ b/packs/gpg/actions/import_keys.py
@@ -11,4 +11,5 @@ class ImportKeysAction(BaseGPGAction):
             key_data = fp.read()
 
         import_result = self._gpg.import_keys(key_data)
+        # pylint: disable=no-member
         return import_result.count

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -33,14 +33,14 @@ if [ -f "${PACK_REQUIREMENTS_FILE}" ]; then
 
         # Create virtualenv
         virtualenv --no-site-packages ${PACK_VIRTUALENV_DIR}
-
-        # Install base dependencies
-        ${PACK_VIRTUALENV_DIR}/bin/pip install -r requirements-dev.txt
-
-        # Install pack dependencies
-        ${PACK_VIRTUALENV_DIR}/bin/pip install -r ${PACK_REQUIREMENTS_FILE}
-        PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
     fi
+
+    # Install base dependencies
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -r requirements-dev.txt
+
+    # Install pack dependencies
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -r ${PACK_REQUIREMENTS_FILE}
+    PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
 else
     PYTHON_BINARY=`which python`
 fi

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -18,27 +18,31 @@ if [ ! -d "${PACK_PATH}/actions" -a ! -d "${PACK_PATH}/sensors" -a ! -d "${PACK_
 fi
 
 
-# We create virtualenv and instasll all the pack dependencies. This way pylint can also
+# We create virtualenv and install all the pack dependencies. This way pylint can also
 # correctly instrospect all the dependency references
 PACK_VIRTUALENV_DIR="/tmp/venv-${PACK_NAME}"
 PACK_REQUIREMENTS_FILE="${PACK_PATH}/requirements.txt"
 PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
 
-# Create virtualenv
-if [ ! -d "${PACK_VIRTUALENV_DIR}" ]; then
-    virtualenv --no-site-packages ${PACK_VIRTUALENV_DIR}
-
-    # Install base dependencies
-    ${PACK_VIRTUALENV_DIR}/bin/pip install -r requirements-dev.txt
-fi
-
 # Install per-pack dependencies
 if [ -f "${PACK_REQUIREMENTS_FILE}" ]; then
-    echo "Installing pack requirements.txt into ${PACK_VIRTUALENV_DIR}"
-
-    # Install dependencies
-    ${PACK_VIRTUALENV_DIR}/bin/pip install -r ${PACK_REQUIREMENTS_FILE}
     PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
+
+    if [ ! -d "${PACK_VIRTUALENV_DIR}" ]; then
+        echo "Installing pack requirements.txt into ${PACK_VIRTUALENV_DIR}"
+
+        # Create virtualenv
+        virtualenv --no-site-packages ${PACK_VIRTUALENV_DIR}
+
+        # Install base dependencies
+        ${PACK_VIRTUALENV_DIR}/bin/pip install -r requirements-dev.txt
+
+        # Install pack dependencies
+        ${PACK_VIRTUALENV_DIR}/bin/pip install -r ${PACK_REQUIREMENTS_FILE}
+        PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
+    fi
+else
+    PYTHON_BINARY=`which python`
 fi
 
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -1,12 +1,14 @@
 #!/usr/bin/env bash
 
+VIRTUALENV_DIR=virtualenv
+
 PACK_PATH=$1
 PACK_NAME=$(basename ${PACK_PATH})
 
 function join { local IFS="$1"; shift; echo "$*"; }
 
 COMPONENTS=$(find /tmp/st2/* -maxdepth 1 -name "st2*" -type d)
-PYTHONPATH=$(join ":" ${COMPONENTS})
+PACK_PYTHONPATH=$(join ":" ${COMPONENTS})
 
 echo "Running pylint on pack: ${PACK_NAME}"
 
@@ -15,6 +17,32 @@ if [ ! -d "${PACK_PATH}/actions" -a ! -d "${PACK_PATH}/sensors" -a ! -d "${PACK_
     exit 0
 fi
 
+
+# We create virtualenv and instasll all the pack dependencies. This way pylint can also
+# correctly instrospect all the dependency references
+PACK_VIRTUALENV_DIR="/tmp/venv-${PACK_NAME}"
+PACK_REQUIREMENTS_FILE="${PACK_PATH}/requirements.txt"
+PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
+
+# Create virtualenv
+if [ ! -d "${PACK_VIRTUALENV_DIR}" ]; then
+    virtualenv --no-site-packages ${PACK_VIRTUALENV_DIR}
+
+    # Install base dependencies
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -r requirements-dev.txt
+fi
+
+# Install per-pack dependencies
+if [ -f "${PACK_REQUIREMENTS_FILE}" ]; then
+    echo "Installing pack requirements.txt into ${PACK_VIRTUALENV_DIR}"
+
+    # Install dependencies
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -r ${PACK_REQUIREMENTS_FILE}
+    PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
+fi
+
+export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
+
 #echo "PYTHONPATH=${PYTHONPATH}"
-export PYTHONPATH=${PYTHONPATH}
-find ${PACK_PATH}/* -name "*.py" -print0 | xargs -0 pylint -E --rcfile=./.pylintrc
+#echo "PYTHON_BINARY=${PYTHON_BINARY}"
+find ${PACK_PATH}/* -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./.pylintrc

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -35,10 +35,10 @@ if [ -f "${PACK_REQUIREMENTS_FILE}" ]; then
     fi
 
     # Install base dependencies
-    ${PACK_VIRTUALENV_DIR}/bin/pip install -r requirements-dev.txt
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -q -r requirements-dev.txt
 
     # Install pack dependencies
-    ${PACK_VIRTUALENV_DIR}/bin/pip install -r ${PACK_REQUIREMENTS_FILE}
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -q -r ${PACK_REQUIREMENTS_FILE}
     PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
 else
     PYTHON_BINARY=`which python`
@@ -48,5 +48,5 @@ export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 
 #echo "PYTHONPATH=${PYTHONPATH}"
 #echo "PYTHON_BINARY=${PYTHON_BINARY}"
-find ${PACK_PATH}/* -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./.pylintrc
+find ${PACK_PATH}/* -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./.pylintrc && echo "No pylint issues found."
 exit $?

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -49,3 +49,4 @@ export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 #echo "PYTHONPATH=${PYTHONPATH}"
 #echo "PYTHON_BINARY=${PYTHON_BINARY}"
 find ${PACK_PATH}/* -name "*.py" -print0 | xargs -0 ${PYTHON_BINARY} -m pylint -E --rcfile=./.pylintrc
+exit $?

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -17,7 +17,6 @@ if [ ! -d "${PACK_PATH}/actions" -a ! -d "${PACK_PATH}/sensors" -a ! -d "${PACK_
     exit 0
 fi
 
-
 # We create virtualenv and install all the pack dependencies. This way pylint can also
 # correctly instrospect all the dependency references
 PACK_VIRTUALENV_DIR="/tmp/venv-${PACK_NAME}"


### PR DESCRIPTION
This pull request updates pylint script to also install Python dependencies for every package which includes requirements.txt file.

This way pylint is also aware of the structure of all the members (modules, classes, etc.) of the dependency package and correctly and better introspect the package code.