### PR TITLE
Install dependencies for packs inside the pylint step

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,8 @@ env:
 cache:
   directories:
     - $HOME/.pip-cache/
+install:
+  - pip install --upgrade pip
 script:
   - ./scripts/travis.sh
 notifications:

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,7 @@ requirements: virtualenv
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate && pip install -q -r requirements-dev.txt
+	. $(VIRTUALENV_DIR)/bin/activate && pip install -q -r requirements-dev.txt --cache-dir $(HOME)/.pip-cache
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV_DIR)/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -55,7 +55,8 @@ requirements: virtualenv
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate && pip install -q -r requirements-dev.txt --cache-dir $(HOME)/.pip-cache
+	. $(VIRTUALENV_DIR)/bin/activate && pip install --cache-dir $(HOME)/.pip-cache -q -r requirements-dev.txt
+	@$(VIRTUALENV_DIR)/bin/pip install --upgrade pip
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV_DIR)/bin/activate

--- a/Makefile
+++ b/Makefile
@@ -55,8 +55,8 @@ requirements: virtualenv
 	@echo
 	@echo "==================== requirements ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate && pip install --cache-dir $(HOME)/.pip-cache -q -r requirements-dev.txt
-	@$(VIRTUALENV_DIR)/bin/pip install --upgrade pip
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --upgrade pip
+	. $(VIRTUALENV_DIR)/bin/activate && $(VIRTUALENV_DIR)/bin/pip install --cache-dir $(HOME)/.pip-cache -q -r requirements-dev.txt
 
 .PHONY: virtualenv
 virtualenv: $(VIRTUALENV_DIR)/bin/activate

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -42,10 +42,10 @@ if [ -f "${PACK_REQUIREMENTS_FILE}" ]; then
     fi
 
     # Install base dependencies
-    ${PACK_VIRTUALENV_DIR}/bin/pip install -q -r requirements-dev.txt
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -q -r requirements-dev.txt --cache-dir ${HOME}/.pip-cache
 
     # Install pack dependencies
-    ${PACK_VIRTUALENV_DIR}/bin/pip install -q -r ${PACK_REQUIREMENTS_FILE}
+    ${PACK_VIRTUALENV_DIR}/bin/pip install -q -r ${PACK_REQUIREMENTS_FILE} --cache-dir ${HOME}/.pip-cache
 else
     PYTHON_BINARY=`which python`
 fi

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -7,8 +7,8 @@ PYTHON_BINARY=`which python`
 
 function join { local IFS="$1"; shift; echo "$*"; }
 
-echo $PYTHON_BINARY
-
+# Note: We assume this script is running inside a virtual environment into which we install the
+# the pack dependencies. This way pylint can also correctly instrospect all the dependency,
 if [[ ${PYTHON_BINARY} != *"virtualenv/bin/python" ]]; then
     echo "Script must run under a virtual environment which is created in the Make target"
     exit 2
@@ -19,8 +19,8 @@ PACK_PYTHONPATH=$(join ":" ${COMPONENTS})
 
 echo "Running pylint on pack: ${PACK_NAME}"
 
-if [ ! -d "${PACK_PATH}/actions" -a ! -d "${PACK_PATH}/sensors" -a ! -d "${PACK_PATH}/etc" ]; then
-    echo "Skipping pack without any actions and sensors"
+if [ ! -d "${pack_path}/actions" -a ! -d "${pack_path}/sensors" -a ! -d "${pack_path}/etc" ]; then
+    echo "skipping pack without any actions and sensors"
     exit 0
 fi
 
@@ -31,19 +31,12 @@ if [ "${PYTHON_FILE_COUNT}" == "0" ]; then
     exit 0
 fi
 
-# Note: We assume this script is running inside a virtual environment into which we install the
-# the pack dependencies.This way pylint can also correctly instrospect all the dependency
-# references.
-PACK_VIRTUALENV_DIR="/tmp/venv-packs"
-PACK_REQUIREMENTS_FILE="${PACK_PATH}/requirements.txt"
-PYTHON_BINARY=${PACK_VIRTUALENV_DIR}/bin/python
-
 # Install per-pack dependencies
 # Install base dependencies
-${PACK_VIRTUALENV_DIR}/bin/pip install -q -r requirements-dev.txt --cache-dir ${HOME}/.pip-cache
+pip install --cache-dir ${HOME}/.pip-cache -q -r requirements-dev.txt
 
 # Install pack dependencies
-${PACK_VIRTUALENV_DIR}/bin/pip install -q -r ${PACK_REQUIREMENTS_FILE} --cache-dir ${HOME}/.pip-cache
+pip install --cache-dir ${HOME}/.pip-cach -q -r ${PACK_REQUIREMENTS_FILE}
 
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -38,7 +38,7 @@ pip install --cache-dir ${HOME}/.pip-cache -q -r requirements-dev.txt
 
 # Install pack dependencies
 if [ -f ${PACK_REQUIREMENTS_FILE} ]; then
-    pip install --cache-dir ${HOME}/.pip-cach -q -r ${PACK_REQUIREMENTS_FILE}
+    pip install --cache-dir ${HOME}/.pip-cache -q -r ${PACK_REQUIREMENTS_FILE}
 fi
 
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -3,6 +3,7 @@
 PACK_PATH=$1
 PACK_NAME=$(basename ${PACK_PATH})
 
+PACK_REQUIREMENTS_FILE="${PACK_PATH}/requirements.txt"
 PYTHON_BINARY=`which python`
 
 function join { local IFS="$1"; shift; echo "$*"; }
@@ -36,7 +37,9 @@ fi
 pip install --cache-dir ${HOME}/.pip-cache -q -r requirements-dev.txt
 
 # Install pack dependencies
-pip install --cache-dir ${HOME}/.pip-cach -q -r ${PACK_REQUIREMENTS_FILE}
+if [ -f ${PACK_REQUIREMENTS_FILE} ]; then
+    pip install --cache-dir ${HOME}/.pip-cach -q -r ${PACK_REQUIREMENTS_FILE}
+fi
 
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 


### PR DESCRIPTION
Like #207, but it uses a single global virtulenv for all the packs.

This way it should be faster and hopefully not time out on Travis.