### PR TITLE
Add "disable_formatting" parameter to the slack.post_message action

### DIFF
--- a/packs/slack/actions/post_message.py
+++ b/packs/slack/actions/post_message.py
@@ -11,7 +11,8 @@ __all__ = [
 
 
 class PostMessageAction(Action):
-    def run(self, message, username=None, icon_emoji=None, channel=None):
+    def run(self, message, username=None, icon_emoji=None, channel=None,
+            disable_formatting=False):
         config = self.config['post_message_action']
         username = username if username else config['username']
         icon_emoji = icon_emoji if icon_emoji else config.get('icon_emoji', None)
@@ -27,6 +28,9 @@ class PostMessageAction(Action):
 
         if channel:
             body['channel'] = channel
+
+        if disable_formatting:
+            body['parse'] = 'none'
 
         data = 'payload=%s' % (json.dumps(body))
         response = requests.post(url=config['webhook_url'],

--- a/packs/slack/actions/post_message.yaml
+++ b/packs/slack/actions/post_message.yaml
@@ -21,3 +21,8 @@
       type: "string"
       description: "Bot icon"
       required: false
+    disable_formatting:
+      type: "boolean"
+      description: "Disable formatting, don't parse the message and treat it as raw text"
+      required: false
+      default: false


### PR DESCRIPTION
With this parameter user can disable formatting and parsing of the message.

![screenshot from 2015-06-01 16 46 44](https://cloud.githubusercontent.com/assets/125088/7909303/d67c8948-087d-11e5-88f8-d87a2bec434f.png)
