### PR TITLE
Resolving: post message returns status 'success', even though it fails

### DIFF
--- a/packs/slack/actions/post_message.py
+++ b/packs/slack/actions/post_message.py
@@ -39,7 +39,8 @@ class PostMessageAction(Action):
         if response.status_code == httplib.OK:
             self.logger.info('Message successfully posted')
         else:
-            self.logger.exception('Failed to post message: %s' % (response.text))
-            raise Exception(response.text)
+            failure_reason = 'Failed to post message: %s (Status Code: %s)' % (response.text, response.status_code)
+            self.logger.exception(failure_reason)
+            raise Exception(failure_reason)
 
         return True

--- a/packs/slack/actions/post_message.py
+++ b/packs/slack/actions/post_message.py
@@ -39,7 +39,8 @@ class PostMessageAction(Action):
         if response.status_code == httplib.OK:
             self.logger.info('Message successfully posted')
         else:
-            failure_reason = 'Failed to post message: %s (Status Code: %s)' % (response.text, response.status_code)
+            failure_reason = ('Failed to post message: %s (Status Code: %s)' % 
+                              (response.text, response.status_code))
             self.logger.exception(failure_reason)
             raise Exception(failure_reason)
 

--- a/packs/slack/actions/post_message.py
+++ b/packs/slack/actions/post_message.py
@@ -40,5 +40,6 @@ class PostMessageAction(Action):
             self.logger.info('Message successfully posted')
         else:
             self.logger.exception('Failed to post message: %s' % (response.text))
+            raise Exception(response.text)
 
         return True


### PR DESCRIPTION
I am trying to run a slack.post_message and it fails with error, and goes into 
    else:
            self.logger.exception('Failed to post message: %s' % (response.text))
branch. The overall return status is, however, still 'Succeeded'. So suggesting to raise the received message in this case as exception:
    raise Exception(response.text)