### PR TITLE
[IMAP Sensor] Support for automatically downloading and storing message attachments in the datastore

### DIFF
--- a/packs/email/README.md
+++ b/packs/email/README.md
@@ -45,10 +45,10 @@ The following attachment settings can be configured:
 
 * ``download_attachments`` - True to download the attachment and store them in the
   datastore.
-* ``max_attachment_size`` - Maximum size of download attachment. If an attachment
-  excedes this size it will be skipped and not downloaded.
-* ``attachment_datastore_ttl`` - TTL for the attachment value which is stored in the
-  datastore.
+* ``max_attachment_size`` - Maximum size of download attachment bytes. If an
+  attachment exceeds this size it will be skipped and not downloaded.
+* ``attachment_datastore_ttl`` - TTL in seconds for the attachment value which is
+  stored in the datastore.
 
 If ``download_attachments`` attribute for a particular IMAP server is set to ``True``,
 attachments will be automatically downloaded and stored in the built-in datastore under

--- a/packs/email/README.md
+++ b/packs/email/README.md
@@ -28,6 +28,7 @@ imap_mailboxes:
     username: "james@stackstorm.com"
     password: "superawesomepassword"
     ssl: True
+    download_attachments: False
   alternate:
     server: "mail.stackstorm.net"
     port: 143
@@ -35,4 +36,147 @@ imap_mailboxes:
     password: "esteetew"
     folder: "StackStorm"
     ssl: True
+    download_attachments: True
+max_attachment_size: 1024
+attachment_datastore_ttl: 1800
+```
+
+The following attachment settings can be configured:
+
+* ``download_attachments`` - True to download the attachment and store them in the
+  datastore.
+* ``max_attachment_size`` - Maximum size of download attachment. If an attachment
+  excedes this size it will be skipped and not downloaded.
+* ``attachment_datastore_ttl`` - TTL for the attachment value which is stored in the
+  datastore.
+
+If ``download_attachments`` attribute for a particular IMAP server is set to ``True``,
+attachments will be automatically downloaded and stored in the built-in datastore under
+a unique key. This key will be available in the trigger payload (see the trigger example
+bellow) so you can retrieve those attachments later (e.g. inside an action).
+
+By default, those values have a TTL of 30 minutes which means they will be automatically remvoed
+from the datastore after 30 minutes.
+
+#### email.imap.message trigger
+
+Example trigger payload:
+
+```json
+{
+    "uid": 5780,
+    "message_id": "<CAJMHEmJs_5hO_PS9huzTAOv60xkTvYz7ETd1=WXFdpa-bzGpUA@mail.gmail.com>",
+    "from": "Tomaž Muraus<tomaz@tomaz.me>",
+    "to": "Tomaz Muraus <tomaz.muraus@gmail.com>",
+    "subject": "test email with attachment"
+    "body": "hello from stackstorm!\n",
+    "headers": [
+        [
+            "Delivered-To",
+            "tomaz.muraus@gmail.com"
+        ],
+        [
+            "Received",
+            "by 10.182.33.5 with SMTP id n5csp2470866obi;        Wed, 10 Jun 2015 00:01:41 -0700 (PDT)"
+        ],
+        [
+            "X-Received",
+            "by 10.50.61.130 with SMTP id p2mr3867507igr.9.1433919701526;        Wed, 10 Jun 2015 00:01:41 -0700 (PDT)"
+        ],
+        [
+            "Return-Path",
+            "<kami@k5-storitve.net>"
+        ],
+        [
+            "Received",
+            "from mail-ig0-x230.google.com (mail-ig0-x230.google.com. [2607:f8b0:4001:c05::230])        by mx.google.com with ESMTPS id we7si8228902icb.8.2015.06.10.00.01.41        for <tomaz.muraus@gmail.com>        (version=TLSv1.2 cipher=ECDHE-RSA-AES128-GCM-SHA256 bits=128/128);        Wed, 10 Jun 2015 00:01:41 -0700 (PDT)"
+        ],
+        [
+            "Received-Spf",
+            "pass (google.com: domain of kami@k5-storitve.net designates 2607:f8b0:4001:c05::230 as permitted sender) client-ip=2607:f8b0:4001:c05::230;"
+        ],
+        [
+            "Authentication-Results",
+            "mx.google.com;       spf=pass (google.com: domain of kami@k5-storitve.net designates 2607:f8b0:4001:c05::230 as permitted sender) smtp.mail=kami@k5-storitve.net;       dkim=pass header.i=@tomaz.me"
+        ],
+        [
+            "Received",
+            "by mail-ig0-x230.google.com with SMTP id pi8so28796173igb.0        for <tomaz.muraus@gmail.com>; Wed, 10 Jun 2015 00:01:41 -0700 (PDT)"
+        ],
+        [
+            "Dkim-Signature",
+            "v=1; a=rsa-sha256; c=relaxed/relaxed;        d=k5-storitve.net; s=google;        h=mime-version:sender:from:date:message-id:subject:to:content-type;        bh=dnyggWfMbPP+DPkMG3PmSW5Y7wvt84XbnBhbgnAUusg=;        b=VmO+M+kBxVU7BwCzreI3vza5kvkxUwkCsiZrlunnMfMnP60RJBJHhE3HtQmIITkjoD         v5fAou2vcSIm5eY/CYAbSJyzzhP6sNbVoHJl1Q90Gqb1KA8g3+hF+mBOBhIqEf0fKiRt         07f0maRrvwJdI54HHRuroE7jSs8DHNllWBJfY="
+        ],
+        [
+            "Dkim-Signature",
+            "v=1; a=rsa-sha256; c=relaxed/relaxed;        d=tomaz.me; s=google;        h=mime-version:sender:from:date:message-id:subject:to:content-type;        bh=dnyggWfMbPP+DPkMG3PmSW5Y7wvt84XbnBhbgnAUusg=;        b=YQGGwcMru9HaWMTbcEtkDdALkSLwEANo/ruZ76REaeW8Hnj0U6aM+MLLRKLsiFwSM+         THzY92cpVDAlYkbDLyqN+PctHyOx3ofRobRjjv2741SzV8ZTYLPSyaqsLtOJlRbfo16m         U+9vVgux9/xGrGQnF4DckO86DlcDPPL4oPgBI="
+        ],
+        [
+            "X-Google-Dkim-Signature",
+            "v=1; a=rsa-sha256; c=relaxed/relaxed;        d=1e100.net; s=20130820;        h=x-gm-message-state:mime-version:sender:from:date:message-id:subject         :to:content-type;        bh=dnyggWfMbPP+DPkMG3PmSW5Y7wvt84XbnBhbgnAUusg=;        b=TEvRNj86wdtz8SQWp1TfqIYOyFbVh6aEhVWcO1hXFf26fh6M36pRTty48qDzCN7dZb         hHZuKLTneCcgnhnt6bbVgR23AkeMtujFc2QGawF3e/So6Z8VGc1VMBoCdd3li0Epqj+w         OisxHlzV5HNhkcj+UB77345yGZBapcgoZxtn5/m6OaL+wDlWjLfgu0j0FHiMDlftJgF3         yMkgONFIZyVqz1xOey4rvjNBNpGowfF9ei0r869PzUjVLtYuw2UuvhXn0AbduxQHMxmA         1QY67srbOsz5DR+u0bX+2euzI7s5KDFCh1hredYctdr87lyEhJew6HYfCNYUXxxLF5R+         h8Wg=="
+        ],
+        [
+            "X-Gm-Message-State",
+            "ALoCoQmCaIs0LyyKWSiGNbUHv6N6osKVmVAuQ7zqUeNA+/7uh8fopFqq/hoF6Fry25ZELwjwbEPr"
+        ],
+        [
+            "X-Received",
+            "by 10.42.203.4 with SMTP id fg4mr3192769icb.52.1433919701095; Wed, 10 Jun 2015 00:01:41 -0700 (PDT)"
+        ],
+        [
+            "Mime-Version",
+            "1.0"
+        ],
+        [
+            "Sender",
+            "kami@k5-storitve.net"
+        ],
+        [
+            "Received",
+            "by 10.50.43.66 with HTTP; Wed, 10 Jun 2015 00:01:20 -0700 (PDT)"
+        ],
+        [
+            "From",
+            "Tomaž Muraus <tomaz@tomaz.me>"
+        ],
+        [
+            "Date",
+            "Wed, 10 Jun 2015 15:01:20 +0800"
+        ],
+        [
+            "X-Google-Sender-Auth",
+            "WfbOSpNXpbHPX2uAz0lP7j-8z7g"
+        ],
+        [
+            "Message-Id",
+            "<CAJMHEmJs_5hO_PS9huzTAOv60xkTvYz7ETd1=WXFdpa-bzGpUA@mail.gmail.com>"
+        ],
+        [
+            "Subject",
+            "test email with attachment"
+        ],
+        [
+            "To",
+            "Tomaz Muraus <tomaz.muraus@gmail.com>"
+        ],
+        [
+            "Content-Type",
+            [
+                "multipart/mixed",
+                {
+                    "boundary": "20cf303f64066bc8ff0518247248"
+                }
+            ]
+        ]
+    ],
+    "date": "Wed, 10 Jun 2015 15:01:20 +0800",
+    "has_attachments": true,
+    "attachments": [
+        {
+            "file_name": "hello stackstorm.txt",
+            "datastore_key": "attachments-0d61eabdb749789c96853dcbbd933884",
+            "content_type": "text/plain"
+        }
+    ]
+}
 ```

--- a/packs/email/README.md
+++ b/packs/email/README.md
@@ -46,7 +46,7 @@ The following attachment settings can be configured:
 * ``download_attachments`` - True to download the attachment and store them in the
   datastore.
 * ``max_attachment_size`` - Maximum size of download attachment bytes. If an
-  attachment exceeds this size it will be skipped and not downloaded.
+  attachment exceeds this size the attachment won't be stored in the datastore.
 * ``attachment_datastore_ttl`` - TTL in seconds for the attachment value which is
   stored in the datastore.
 

--- a/packs/email/README.md
+++ b/packs/email/README.md
@@ -58,6 +58,9 @@ bellow) so you can retrieve those attachments later (e.g. inside an action).
 By default, those values have a TTL of 30 minutes which means they will be automatically remvoed
 from the datastore after 30 minutes.
 
+Keep in mind that all the attachments which contain binary (non plain-text, mime-type
+!= text/plain) data are base64 encoded before they are stored in the datastore.
+
 #### email.imap.message trigger
 
 Example trigger payload:

--- a/packs/email/config.yaml
+++ b/packs/email/config.yaml
@@ -7,6 +7,10 @@ imap_mailboxes:
     username: ""
     password: ""
     ssl: True
+    download_attachments: True
+
+max_attachment_size: 1024
+attachment_datastore_ttl: 1800
 
 smtp_listen_ip: '127.0.0.1'
 smtp_listen_port: 25

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -106,7 +106,7 @@ class IMAPSensor(PollingSensor):
     def _poll_for_unread_messages(self, name, mailbox, download_attachments=False):
         self._logger.debug('[IMAPSensor]: polling mailbox {0}'.format(name))
 
-        for message in mailbox.unread():
+        for message in mailbox.unseen():
             self._process_message(uid=message.uid, mailbox=mailbox,
                                   download_attachments=download_attachments)
             return

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -106,10 +106,12 @@ class IMAPSensor(PollingSensor):
     def _poll_for_unread_messages(self, name, mailbox, download_attachments=False):
         self._logger.debug('[IMAPSensor]: polling mailbox {0}'.format(name))
 
-        for message in mailbox.unseen():
+        messages = mailbox.unseen()
+
+        self._logger.debug('[IMAPSensor]: Processing {0} new messages'.format(len(messages)))
+        for message in messages:
             self._process_message(uid=message.uid, mailbox=mailbox,
                                   download_attachments=download_attachments)
-            return
 
     def _process_message(self, uid, mailbox, download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
         message = mailbox.mail(uid, include_raw=True)

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -66,13 +66,19 @@ class IMAPSensor(PollingSensor):
             if not user or not password:
                 self._logger.debug("""[IMAPSensor]: Missing
                     username/password for {0}""".format(mailbox))
-            elif not server:
+                continue
+
+            if not server:
                 self._logger.debug("""[IMAPSensor]: Missing server
                     for {0}""".format(mailbox))
-            else:
+                continue
+
+            try:
                 connection = easyimap.connect(server, user, password,
                                               folder, ssl=ssl, port=port)
-                self._mailboxes[mailbox] = connection
+            except Exception as e:
+                message = 'Failed to connect to mailbox "%s": %s' % (mailbox, str(e))
+                raise Exception(message)
 
     def _poll_for_unread_messages(self, name, mailbox):
         self._logger.debug('[IMAPSensor]: polling mailbox {0}'.format(name))

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -1,4 +1,5 @@
 import hashlib
+import base64
 
 import eventlet
 import easyimap
@@ -164,8 +165,11 @@ class IMAPSensor(PollingSensor):
                                                                file_name=file_name)
 
             # Store attachment in the datastore
-            # TODO: Verify with binary attachments
-            value = content
+            if content_type == 'text/plain':
+                value = content
+            else:
+                value = base64.b64encode(content)
+
             self._sensor_service.set_value(name=datastore_key, value=value,
                                            ttl=self._attachment_datastore_ttl,
                                            local=False)

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -33,7 +33,7 @@ class IMAPSensor(PollingSensor):
         self._logger = self._sensor_service.get_logger(__name__)
 
         self._max_attachment_size = self._config.get('max_attachment_size',
-                                                      DEFAULT_MAX_ATTACHMENT_SIZE)
+                                                     DEFAULT_MAX_ATTACHMENT_SIZE)
         self._attachment_datastore_ttl = self._config.get('attachment_datastore_ttl',
                                                           DEFAULT_MAX_ATTACHMENT_SIZE)
         self._mailboxes = {}
@@ -158,7 +158,8 @@ class IMAPSensor(PollingSensor):
 
             if len(content) > self._max_attachment_size:
                 self._logger.debug(('[IMAPSensor]: Skipping attachment "{}" since its bigger '
-                                    'than maximum allowed size ({})'.format(file_name, attachment_size)))
+                                    'than maximum allowed size ({})'.format(file_name,
+                                                                            attachment_size)))
                 continue
 
             datastore_key = self._get_attachment_datastore_key(message=message,


### PR DESCRIPTION
This pull request adds support for automatically downloading and store message attachments in the datastore.

This allows users to retrieve those attachments from a datastore later (e.g. inside an action).

For more information on how it works, pleasae refer to the readme.