### PR TITLE
OpenHAB integration pack

### DIFF
--- a/packs/openhab/README.md
+++ b/packs/openhab/README.md
@@ -1,0 +1,16 @@
+# OpenHAB Integration Pack
+
+This integration pack allows you to integratie with [OpenHAB](http://openhab.org).
+
+## Configuration
+
+* `host` - Hostname of OpenHAB
+* `port` - Port OpenHAB listens on (default: 8080)
+* `username` - Username to connect to OpenHAB (optional)
+* `password` - Password to connect to OpenHAB (optional)
+
+## Actions
+
+* `get_status` - Set the status of an OpenHAB item
+* `send_command` - Send a command to an OpenHAB item
+* `set_state` - Set the state of an OpenHAB item

--- a/packs/openhab/README.md
+++ b/packs/openhab/README.md
@@ -4,7 +4,7 @@ This integration pack allows you to integratie with [OpenHAB](http://openhab.org
 
 ## Configuration
 
-* `host` - Hostname of OpenHAB
+* `hostname` - Hostname of OpenHAB
 * `port` - Port OpenHAB listens on (default: 8080)
 * `username` - Username to connect to OpenHAB (optional)
 * `password` - Password to connect to OpenHAB (optional)

--- a/packs/openhab/actions/README.md
+++ b/packs/openhab/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/openhab/actions/get_status.py
+++ b/packs/openhab/actions/get_status.py
@@ -1,0 +1,6 @@
+from lib.action import BaseAction
+
+
+class GetStatusAction(BaseAction):
+    def run(self, item, command):
+        return self._get(item, command)

--- a/packs/openhab/actions/get_status.py
+++ b/packs/openhab/actions/get_status.py
@@ -2,5 +2,5 @@ from lib.action import BaseAction
 
 
 class GetStatusAction(BaseAction):
-    def run(self, item, command):
-        return self._get(item, command)
+    def run(self, item):
+        return self._get(item)

--- a/packs/openhab/actions/get_status.yaml
+++ b/packs/openhab/actions/get_status.yaml
@@ -1,0 +1,11 @@
+---
+name: "get_status"
+runner_type: "python-script"
+description: "Get status on an item"
+enabled: true
+entry_point: "get_status.py"
+parameters:
+  item:
+    type: "string"
+    description: "Item to get status of"
+    required: true

--- a/packs/openhab/actions/get_status.yaml
+++ b/packs/openhab/actions/get_status.yaml
@@ -8,4 +8,3 @@ parameters:
   item:
     type: "string"
     description: "Item to get status of"
-    required: true

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -12,7 +12,7 @@ class BaseAction(Action):
         self.password = self.config.get('password', None)
         self.hostname = self.config.get('hostname', None)
         self.port = self.config.get('port', 8080)
-        self.url = "{}:{}/rest/items".format(self.username, self.password)
+        self.url = "{}:{}/rest/items".format(self.hostname, self.port)
 
         if self.username and self.password:
             self.auth = base64.encodestring('%s:%s'

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -45,10 +45,8 @@ class BaseAction(Action):
         return self._parse_req(req)
 
     def _parse_req(self, req):
-        if req.status_code != requests.codes.ok:
-            req.raise_for_status()
-        else:
-            try:
-                return req.json()
-            except:
-                return req.text
+        req.raise_for_status()
+        try:
+            return req.json()
+        except:
+            return req.text

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -29,7 +29,7 @@ class BaseAction(Action):
         return payload
 
     def _get(self, key):
-        url = "{}/{}".format(self.url, key)
+        url = "{}/{}".format(self.url, key) if key else self.url
         payload = {'type': 'json'}
         req = requests.get(url, params=payload, headers=self._headers())
         return self._parse_req(req)

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -31,17 +31,17 @@ class BaseAction(Action):
     def _get(self, key):
         url = "{}/{}".format(self.url, key)
         payload = {'type': 'json'}
-        req = requests.get(url, params=payload, headers=self.headers())
+        req = requests.get(url, params=payload, headers=self._headers())
         return self._parse_req(req)
 
     def _put(self, key, value):
         url = "{}/{}/state".format(self.url, key)
-        req = requests.put(url, data=value, headers=self.headers())
+        req = requests.put(url, data=value, headers=self._headers())
         return self._parse_req(req)
 
     def _post(self, key, value):
         url = "{}/{}".format(self.url, key)
-        req = requests.post(url, data=value, headers=self.headers())
+        req = requests.post(url, data=value, headers=self._headers())
         return self._parse_req(req)
 
     def _parse_req(self, req):

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -15,9 +15,8 @@ class BaseAction(Action):
         self.url = "{}:{}/rest/items".format(self.hostname, self.port)
 
         if self.username and self.password:
-            self.auth = base64.encodestring('%s:%s'
-                              % (self.username, self.password)
-                              ).replace('\n', '')
+            self.auth = base64.encodestring(
+                '%s:%s' % (self.username, self.password)).replace('\n', '')
 
     def _headers(self):
         payload = {

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -44,7 +44,7 @@ class BaseAction(Action):
         req = requests.post(url, data=value, headers=self.headers())
         return self._parse_req(req)
 
-    def _parse_req(req):
+    def _parse_req(self, req):
         if req.status_code != requests.codes.ok:
             req.raise_for_status()
         else:

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -1,0 +1,63 @@
+import requests
+import base64
+from st2actions.runners.pythonrunner import Action
+
+
+class BaseAction(Action):
+    def __init__(self, config):
+        super(BaseAction, self).__init__(config)
+
+        self.auth = None
+        self.username = self.config.get('username', None)
+        self.password = self.config.get('password', None)
+        self.hostname = self.config.get('hostname', None)
+        self.port = self.config.get('port', 8080)
+        self.url = "{}:{}/rest/items".format(self.username, self.password)
+
+        if self.username and self.password:
+            self.auth = base64.encodestring('%s:%s'
+                               %(self.username, self.password)
+                               ).replace('\n', '')
+
+    def _headers(self):
+        payload = {
+            "Content-type": "text/plain",
+            "Accept": "application/json"
+        }
+        if self.auth:
+            payload['Authentication'] = "Basic {}".format(self.auth)
+        return payload
+
+    def _get(self, key):
+        url = "{}/{}".format(self.url, key)
+        payload = {'type': 'json'}
+        req = requests.get(url, params=payload, headers=self.headers())
+        if req.status_code != requests.codes.ok:
+            req.raise_for_status()
+        else:
+            try:
+                return req.json()
+            except:
+                return req.text
+
+    def _put(self, key, value):
+        url = "{}/{}/state".format(self.url, key)
+        req = requests.put(url, data=value, headers=self.headers())
+        if req.status_code != requests.codes.ok:
+            req.raise_for_status()
+        else:
+            try:
+                return req.json()
+            except:
+                return req.text
+
+    def _post(self, key, value):
+        url = "{}/{}".format(self.url, key)
+        req = requests.post(url, data=value, headers=self.headers())
+        if req.status_code != requests.codes.ok:
+            req.raise_for_status()
+        else:
+            try:
+                return req.json()
+            except:
+                return req.text

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -32,28 +32,19 @@ class BaseAction(Action):
         url = "{}/{}".format(self.url, key)
         payload = {'type': 'json'}
         req = requests.get(url, params=payload, headers=self.headers())
-        if req.status_code != requests.codes.ok:
-            req.raise_for_status()
-        else:
-            try:
-                return req.json()
-            except:
-                return req.text
+        return self._parse_req(req)
 
     def _put(self, key, value):
         url = "{}/{}/state".format(self.url, key)
         req = requests.put(url, data=value, headers=self.headers())
-        if req.status_code != requests.codes.ok:
-            req.raise_for_status()
-        else:
-            try:
-                return req.json()
-            except:
-                return req.text
+        return self._parse_req(req)
 
     def _post(self, key, value):
         url = "{}/{}".format(self.url, key)
         req = requests.post(url, data=value, headers=self.headers())
+        return self._parse_req(req)
+
+    def _parse_req(req):
         if req.status_code != requests.codes.ok:
             req.raise_for_status()
         else:

--- a/packs/openhab/actions/lib/action.py
+++ b/packs/openhab/actions/lib/action.py
@@ -16,8 +16,8 @@ class BaseAction(Action):
 
         if self.username and self.password:
             self.auth = base64.encodestring('%s:%s'
-                               %(self.username, self.password)
-                               ).replace('\n', '')
+                              % (self.username, self.password)
+                              ).replace('\n', '')
 
     def _headers(self):
         payload = {

--- a/packs/openhab/actions/send_command.py
+++ b/packs/openhab/actions/send_command.py
@@ -1,0 +1,7 @@
+from lib.action import BaseAction
+
+
+class SendCommandAction(BaseAction):
+    def run(self, item, command):
+        self._post(item, command)
+        return {'status': 'ok'}

--- a/packs/openhab/actions/send_command.yaml
+++ b/packs/openhab/actions/send_command.yaml
@@ -1,0 +1,15 @@
+---
+name: "send_command"
+runner_type: "python-script"
+description: "Send a command to an item"
+enabled: true
+entry_point: "send_command.py"
+parameters:
+  item:
+    type: "string"
+    description: "Item to send commands to"
+    required: true
+  command:
+    type: "string"
+    description: "Command to send"
+    required: true

--- a/packs/openhab/actions/set_state.py
+++ b/packs/openhab/actions/set_state.py
@@ -1,7 +1,7 @@
 from lib.action import BaseAction
 
 
-class SetStatusAction(BaseAction):
+class SetStateAction(BaseAction):
     def run(self, item, command):
         self._put(item, command)
         return {'status': 'ok'}

--- a/packs/openhab/actions/set_state.py
+++ b/packs/openhab/actions/set_state.py
@@ -2,6 +2,6 @@ from lib.action import BaseAction
 
 
 class SetStateAction(BaseAction):
-    def run(self, item, command):
-        self._put(item, command)
+    def run(self, item, state):
+        self._put(item, state)
         return {'status': 'ok'}

--- a/packs/openhab/actions/set_state.yaml
+++ b/packs/openhab/actions/set_state.yaml
@@ -1,13 +1,13 @@
 ---
-name: "set_status"
+name: "set_state"
 runner_type: "python-script"
-description: "Set status on an item"
+description: "Set state on an item"
 enabled: true
-entry_point: "set_status.py"
+entry_point: "set_state.py"
 parameters:
   item:
     type: "string"
-    description: "Item to send commands to"
+    description: "Item to set state on"
     required: true
   state:
     type: "string"

--- a/packs/openhab/actions/set_status.py
+++ b/packs/openhab/actions/set_status.py
@@ -1,0 +1,7 @@
+from lib.action import BaseAction
+
+
+class SetStatusAction(BaseAction):
+    def run(self, item, command):
+        self._put(item, command)
+        return {'status': 'ok'}

--- a/packs/openhab/actions/set_status.yaml
+++ b/packs/openhab/actions/set_status.yaml
@@ -1,0 +1,15 @@
+---
+name: "set_status"
+runner_type: "python-script"
+description: "Set status on an item"
+enabled: true
+entry_point: "set_status.py"
+parameters:
+  item:
+    type: "string"
+    description: "Item to send commands to"
+    required: true
+  state:
+    type: "string"
+    description: "Value to set state of an item to"
+    required: true

--- a/packs/openhab/config.yaml
+++ b/packs/openhab/config.yaml
@@ -1,0 +1,8 @@
+### Place configuration data for your pack here.
+---
+host: "http://localhost"
+port: "8080"
+
+## Optional
+# username: ""
+# password: ""

--- a/packs/openhab/config.yaml
+++ b/packs/openhab/config.yaml
@@ -1,6 +1,6 @@
 ### Place configuration data for your pack here.
 ---
-host: "http://localhost"
+hostname: "http://localhost"
 port: "8080"
 
 ## Optional

--- a/packs/openhab/pack.yaml
+++ b/packs/openhab/pack.yaml
@@ -1,0 +1,7 @@
+### Place information about your pack version here.
+---
+name: openhab
+description: Integraition with OpenHAB
+version: 0.1.0
+author: James Fryman
+email: james@stackstorm.com

--- a/packs/openhab/rules/README.md
+++ b/packs/openhab/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/openhab/sensors/README.md
+++ b/packs/openhab/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.


### PR DESCRIPTION
This PR introduces support for OpenHAB, a home-automation platform with similar goals as StackStorm, but with a different focus. This introduces some basic actions that allow StackStorm to proxy commands to OpenHAB via Actions/Workflow/ChatOps.

## Configuration

* `hostname` - Hostname of OpenHAB
* `port` - Port OpenHAB listens on (default: 8080)
* `username` - Username to connect to OpenHAB (optional)
* `password` - Password to connect to OpenHAB (optional)

## Actions

* `get_status` - Set the status of an OpenHAB item
* `send_command` - Send a command to an OpenHAB item
* `set_state` - Set the state of an OpenHAB item

