### PR TITLE
Better message formatting for Hubot

### DIFF
--- a/packs/hubot/actions/post_result.py
+++ b/packs/hubot/actions/post_result.py
@@ -2,7 +2,7 @@ import json
 import httplib
 import requests
 import six
-import yaml
+import pyaml
 from six.moves.urllib.parse import urljoin
 
 from st2actions.runners.pythonrunner import Action
@@ -13,7 +13,7 @@ __all__ = [
 
 
 def _serialize(data):
-    return yaml.safe_dump(data, default_flow_style=False)
+    return pyaml.dump(data)
 
 
 def format_possible_failure_result(result):

--- a/packs/hubot/requirements.txt
+++ b/packs/hubot/requirements.txt
@@ -1,2 +1,3 @@
 requests>=2.5.1,<2.6
 six
+pyaml

--- a/packs/hubot/requirements.txt
+++ b/packs/hubot/requirements.txt
@@ -1,3 +1,3 @@
+pyaml
 requests>=2.5.1,<2.6
 six
-pyaml


### PR DESCRIPTION
This enhances `post_result` message formatting for Hubot.

Replaces `yaml` with [`pyaml`](https://github.com/mk-fg/pretty-yaml) library which chooses more human-readable ways of formatting depending on situation.

#### Before: 
![chatops holy cow broken](http://i.imgur.com/2WzQ4re.png)

#### After:
![chatops holy cow!](http://i.imgur.com/J9E8pTT.png)

