### PR TITLE
Update Twitter Search Sensor

### DIFF
--- a/packs/twitter/README.md
+++ b/packs/twitter/README.md
@@ -11,8 +11,8 @@ Pack which allows integration with Twitter.
 * ``consumer_secret`` - Twitter API consumer secret.
 * ``access_token`` - Twitter API access token.
 * ``access_token_secret`` - Twitter API access token secret.
-* ``query`` - A query to search the twitter timeline for. You can use all the
-  query operators described at https://dev.twitter.com/rest/public/search
+* ``query`` - A query to search the twitter timeline for. Must be an array.
+  You can use all the query operators described at https://dev.twitter.com/rest/public/search
 * ``count`` - Number of latest tweets matching the criteria to retrieve.
   Defaults to 30, maximum is 100.
 * ``language`` - If specified, only return tweets in the provided language.

--- a/packs/twitter/config.yaml
+++ b/packs/twitter/config.yaml
@@ -5,6 +5,7 @@ consumer_secret:
 access_token:
 access_token_secret:
 
-query: "StackStorm OR @Stack_Storm"
+query:
+  - "StackStorm OR @Stack_Storm"
 count: 30
 language: en

--- a/packs/twitter/rules/relay_tweet_to_slack.yaml
+++ b/packs/twitter/rules/relay_tweet_to_slack.yaml
@@ -11,3 +11,4 @@
     ref: "slack.post_message"
     parameters:
         message: "@{{trigger.user.screen_name}} tweeted on {{trigger.created_at}}: {{trigger.text}} - {{trigger.url}}"
+        channel: "#twitter-relay"

--- a/packs/twitter/sensors/twitter_search_sensor.py
+++ b/packs/twitter/sensors/twitter_search_sensor.py
@@ -28,7 +28,8 @@ class TwitterSearchSensor(PollingSensor):
         self._last_id = None
 
         if type(self._config['query']) is not list:
-            self._logger.exception('Polling sensor failed. Cannot start. "query" config value is not a list')
+            self._logger.exception('Twitter sensor failed. "query" config \
+                                    value is not a list')
             raise ValueError('[TwitterSearchSensor]: "query" is not a list')
 
     def poll(self):

--- a/packs/twitter/sensors/twitter_search_sensor.py
+++ b/packs/twitter/sensors/twitter_search_sensor.py
@@ -27,6 +27,10 @@ class TwitterSearchSensor(PollingSensor):
         )
         self._last_id = None
 
+        if type(self._config['query']) is not list:
+            self._logger.exception('Polling sensor failed. Cannot start. "query" config value is not a list')
+            raise ValueError('[TwitterSearchSensor]: "query" is not a list')
+
     def poll(self):
         tso = TwitterSearchOrder()
         tso.set_keywords(self._config['query'])

--- a/packs/twitter/sensors/twitter_search_sensor.py
+++ b/packs/twitter/sensors/twitter_search_sensor.py
@@ -29,7 +29,7 @@ class TwitterSearchSensor(PollingSensor):
 
     def poll(self):
         tso = TwitterSearchOrder()
-        tso.set_keywords([self._config['query']])
+        tso.set_keywords(self._config['query'])
 
         language = self._config.get('language', None)
         if language:


### PR DESCRIPTION
This PR updates the twitter sensor to be able to accept multiple complex search terms. `query` becomes an array, and the user is able to have more than one query going during a poll.