### PR TITLE
Mmonit sensor refactor and bugfixing

### DIFF
--- a/packs/mmonit/README.md
+++ b/packs/mmonit/README.md
@@ -23,6 +23,8 @@ Pack which allows integration with [Mmonit](http://www.mmonit.com/).
 * ``host`` - mmonit host to connect to.
 * ``username`` - Username to connect to mmonit.
 * ``password`` - Password to connect to mmonit.
+* ``event_types`` - Comma separated list of events to listen for. Possible values: 0=success, 1=error, 2=change. 1 and 2 by default.
+* ``active`` - The active events filter. Possible values: 0=show all events, 1=show only active errors, 2=show only active errors but exclude user dismissed errors. Defaults to 1.
 
 
 ## Actions

--- a/packs/mmonit/config.yaml
+++ b/packs/mmonit/config.yaml
@@ -6,3 +6,5 @@ shared_sensors_config:
   host:
   username:
   password:
+  event_types: 1,2
+  active: 1

--- a/packs/mmonit/sensors/events_sensor.py
+++ b/packs/mmonit/sensors/events_sensor.py
@@ -57,7 +57,8 @@ class MmonitEventsSensor(PollingSensor):
         active_events = [str(item['id']) for item in events['records']]
         for k in self._sensor_service.list_values():
             if str(k.value) not in active_events:
-                self._logger.debug('Event {} is no longer active, deleting from the datastore'.format(k.value))
+                self._logger.debug('Event {} is no longer active, '
+                                   'deleting from the datastore'.format(k.value))
                 self._sensor_service.delete_value(k.value)
 
     def _clear_list(self, events):
@@ -68,7 +69,8 @@ class MmonitEventsSensor(PollingSensor):
         new_list = []
         for item in events['records']:
             if str(item['id']) in triggered_events:
-                self._logger.debug('Event {} was already triggered, not triggering it anymore.'.format(item['id']))
+                self._logger.debug('Event {} was already triggered, '
+                                   'not triggering it anymore.'.format(item['id']))
             elif str(item['eventtype']) not in self.event_types:
                 self._logger.debug('Event {} was filtered by the configuration.'.format(item['id']))
             else:

--- a/packs/mmonit/sensors/events_sensor.py
+++ b/packs/mmonit/sensors/events_sensor.py
@@ -33,7 +33,8 @@ class MmonitEventsSensor(PollingSensor):
         if test_login.status_code != 200:
             self._login()
 
-        events_list = self.session.get('{}/reports/events/list'.format(self.url), params={'active': self.active}).json()
+        events_list = self.session.get('{}/reports/events/list'.format(self.url),
+                                       params={'active': self.active}).json()
         events = self._clear_list(events_list)
         self._clear_datastore(events_list)
         for event in events:
@@ -48,8 +49,10 @@ class MmonitEventsSensor(PollingSensor):
         self.session.close()
 
     def _clear_datastore(self, events):
-        """As we store the triggered events in the datastore, this checks if the actual standing alerts
-        from monit are in the datastore, and if they are not then we remove them so they can be triggered again
+        """As we store the triggered events in the datastore,
+        this checks if the actual standing alerts
+        from monit are in the datastore, and if they are not
+        then we remove them so they can be triggered again
         in case the alert arises again"""
         active_events = [str(item['id']) for item in events['records']]
         for k in self._sensor_service.list_values():
@@ -58,8 +61,9 @@ class MmonitEventsSensor(PollingSensor):
                 self._sensor_service.delete_value(k.value)
 
     def _clear_list(self, events):
-        """Removes already triggered events from the events list. This makes long standing alerts
-        that had already been triggered, not get triggered again. So no spam for any rules/workflow"""
+        """Removes already triggered events from the events list.
+        This makes long standing alerts
+        that had already been triggered, not get triggered again."""
         triggered_events = [str(kvp.value) for kvp in self._sensor_service.list_values()]
         new_list = []
         for item in events['records']:

--- a/packs/mmonit/sensors/events_sensor.py
+++ b/packs/mmonit/sensors/events_sensor.py
@@ -9,46 +9,68 @@ class MmonitEventsSensor(PollingSensor):
                                                  poll_interval=poll_interval)
 
     def setup(self):
-        self.url = self._config["shared_sensors_config"]["host"].strip("/")
-        self.user = self._config["shared_sensors_config"]["username"]
-        self.password = self._config["shared_sensors_config"]["password"]
+        self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
+        self.url = self._config['shared_sensors_config']['host'].strip('/')
+        self.user = self._config['shared_sensors_config']['username']
+        self.password = self._config['shared_sensors_config']['password']
+        self.active = self._config['shared_sensors_config']['active']
+        self.event_types = self._config['shared_sensors_config']['event_types'].split(',')
         self.session = requests.session()
         self._login()
 
     def _login(self):
         self.session.get(self.url)
-        data = {"z_csrf_protection": "off",
-                "z_username": self.user,
-                "z_password": self.password}
-        login = self.session.get("{}/z_security_check".format(self.url), data=data)
+        data = {'z_csrf_protection': 'off',
+                'z_username': self.user,
+                'z_password': self.password}
+        login = self.session.post('{}/z_security_check'.format(self.url), data=data)
         if login.status_code != 200:
-            raise Exception("Could not login to mmonit {}".format(login.reason))
+            raise Exception('Could not login to mmonit {}'.format(login.reason))
 
     def poll(self):
         # always check for status_code on a secured page on each poll in case we get logged out
-        test_login = self.session.get("{}/session/get".format(self.url))
+        test_login = self.session.get('{}/session/get'.format(self.url))
         if test_login.status_code != 200:
             self._login()
 
-        events_list = self.session.get("{}/reports/events/list".format(self.url)).json()
+        events_list = self.session.get('{}/reports/events/list'.format(self.url), params={'active': self.active}).json()
         events = self._clear_list(events_list)
+        self._clear_datastore(events_list)
         for event in events:
-            payload = {"host": event['hostname'], "id": event['id'],
-                       "event": event['event'], "servicename": event["servicename"],
-                       "full_data": event}
-            self._sensor_service.dispatch(trigger="mmonit.new_event", payload=payload)
-            self._sensor_service.set_value('monit.last_event', event["id"])
+            payload = {'host': event['hostname'], 'id': event['id'],
+                       'event': event['event'], 'servicename': event['servicename'],
+                       'full_data': event}
+            self._sensor_service.dispatch(trigger='mmonit.new_event', payload=payload)
+            self._sensor_service.set_value(str(event['id']), event['id'])
 
     def cleanup(self):
-        self.session.get("{}/login/logout.csp".format(self.url))
+        self.session.get('{}/login/logout.csp'.format(self.url))
         self.session.close()
 
+    def _clear_datastore(self, events):
+        """As we store the triggered events in the datastore, this checks if the actual standing alerts
+        from monit are in the datastore, and if they are not then we remove them so they can be triggered again
+        in case the alert arises again"""
+        active_events = [str(item['id']) for item in events['records']]
+        for k in self._sensor_service.list_values():
+            if str(k.value) not in active_events:
+                self._logger.debug('Event {} is no longer active, deleting from the datastore'.format(k.value))
+                self._sensor_service.delete_value(k.value)
+
     def _clear_list(self, events):
-        last_event = self._sensor_service.get_value('monit.last_event')
-        for index, item in enumerate(events['records']):
-            if item['id'] > last_event:
-                events['records'].pop(index)
-        return events['records']
+        """Removes already triggered events from the events list. This makes long standing alerts
+        that had already been triggered, not get triggered again. So no spam for any rules/workflow"""
+        triggered_events = [str(kvp.value) for kvp in self._sensor_service.list_values()]
+        new_list = []
+        for item in events['records']:
+            if str(item['id']) in triggered_events:
+                self._logger.debug('Event {} was already triggered, not triggering it anymore.'.format(item['id']))
+            elif str(item['eventtype']) not in self.event_types:
+                self._logger.debug('Event {} was filtered by the configuration.'.format(item['id']))
+            else:
+                self._logger.debug('Event {} looks new. Triggering!'.format(item['id']))
+                new_list.append(item)
+        return new_list
 
     def add_trigger(self, trigger):
         pass


### PR DESCRIPTION
 - add 2 types of filter for a more granulated control of events to listen
 - refactor sensor so it uses the datastore inteligently and does not spam the same events, in case of long standing events
 - clear the datastore when the events dissapear
 - add a logger for debugging
 - log why the events are not being triggered so nobody gets crazy on why they are missing events!
 - make quotes be consisteng across the whole file
 - fix the login using a get instead of the proper post
