### PR TITLE
IMAP Sensor fixes

### DIFF
--- a/packs/email/config.yaml
+++ b/packs/email/config.yaml
@@ -1,16 +1,11 @@
-### Place configuration data for your pack here.
 ---
 imap_mailboxes:
-  default:
-    server: ""
+  steve_main:
+    server: imap.kolabnow.com
     port: 993
-    username: ""
-    password: ""
-    ssl: True
-    download_attachments: True
-
+    username: steve@fryman.io
+    password: bsKpcHdoYQTAmnozhABJWipLxDdmYULXg9stDhti4jPKZdvLih
+    ssl: true
 max_attachment_size: 1024
 attachment_datastore_ttl: 1800
 
-smtp_listen_ip: '127.0.0.1'
-smtp_listen_port: 25

--- a/packs/email/requirements.txt
+++ b/packs/email/requirements.txt
@@ -1,2 +1,2 @@
-flanker>=0.4.28
+flanker>=0.4.33
 easyimap>=0.6.1

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -41,17 +41,19 @@ class IMAPSensor(PollingSensor):
     def setup(self):
         self._logger.debug('[IMAPSensor]: entering setup')
 
-        if 'imap_mailboxes' in self._config:
-            self._parse_mailboxes(self._config['imap_mailboxes'])
 
     def poll(self):
         self._logger.debug('[IMAPSensor]: entering poll')
+
+        if 'imap_mailboxes' in self._config:
+            self._parse_mailboxes(self._config['imap_mailboxes'])
 
         for name, values in self._mailboxes.items():
             mailbox = values['connection']
             download_attachments = values['download_attachments']
             self._poll_for_unread_messages(name=name, mailbox=mailbox,
                                            download_attachments=download_attachments)
+            mailbox.quit()
 
     def cleanup(self):
         self._logger.debug('[IMAPSensor]: entering cleanup')

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -41,7 +41,6 @@ class IMAPSensor(PollingSensor):
     def setup(self):
         self._logger.debug('[IMAPSensor]: entering setup')
 
-
     def poll(self):
         self._logger.debug('[IMAPSensor]: entering poll')
 


### PR DESCRIPTION
This PR fixes two issues with the IMAP sensor.

1) IMAP sensor dies when attempting to read an older message marked as "Unread"
2) IMAP sensor does not properly parse message headers