### PR TITLE
Get rid of pyaml to pretty dump json.

### DIFF
--- a/packs/hubot/actions/post_result.py
+++ b/packs/hubot/actions/post_result.py
@@ -2,7 +2,6 @@ import json
 import httplib
 import requests
 import six
-import pyaml
 from six.moves.urllib.parse import urljoin
 
 from st2actions.runners.pythonrunner import Action
@@ -13,7 +12,9 @@ __all__ = [
 
 
 def _serialize(data):
-    return pyaml.dump(data)
+    if isinstance(data, dict):
+        return '\n'.join(['%s : %s' % (k, v) for k, v in six.iteritems(data)])
+    return data
 
 
 def format_possible_failure_result(result):

--- a/packs/hubot/requirements.txt
+++ b/packs/hubot/requirements.txt
@@ -1,3 +1,2 @@
-pyaml
 requests>=2.5.1,<2.6
 six


### PR DESCRIPTION
* Using the yaml dumper only leads to more escaping and further formatting misery
  so user simpler technique and let original formatting take its course.

This fixes issues https://github.com/StackStorm/hubot-stackstorm/issues/24

<img width="1044" alt="screen shot 2015-07-16 at 4 00 15 pm" src="https://cloud.githubusercontent.com/assets/1776099/8737089/889cdc04-2bd3-11e5-981a-7f99e01fbf68.png">
