### PR TITLE
Fix a bug with special characters in slack.post_message action

### DIFF
--- a/packs/slack/actions/post_message.py
+++ b/packs/slack/actions/post_message.py
@@ -1,6 +1,11 @@
 import json
 import httplib
 
+try:
+    from six.moves.urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode
+
 import requests
 
 from st2actions.runners.pythonrunner import Action
@@ -32,7 +37,8 @@ class PostMessageAction(Action):
         if disable_formatting:
             body['parse'] = 'none'
 
-        data = 'payload=%s' % (json.dumps(body))
+        data = {'payload': json.dumps(body)}
+        data = urlencode(data)
         response = requests.post(url=config['webhook_url'],
                                  headers=headers, data=data)
 

--- a/packs/slack/pack.yaml
+++ b/packs/slack/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : slack
 description : st2 content pack containing slack integrations
-version : 0.1
+version : 0.1.1
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
This pull request fixes a bug in the slack.post_message action - we not correctly escape the request body so it also works if the message contains special characters.