### PR TITLE
Authentication support for st2 pack.

### DIFF
--- a/packs/st2/README.md
+++ b/packs/st2/README.md
@@ -9,7 +9,10 @@ Requires StackStorm >= `v0.8.0`
 * `base_url` - Base URL for the StackStorm API server endpoints (i.e.
   ``http://localhost``). If only the base URL is provided, the client will
   assume default ports for the API servers are used. If any of the API server
-  URL is provided, it will override the base URL and default port.
+  URL is provided, it will override the base URL and default port. If no value
+  is provided will assume the pack is expected to work with current StackStorm
+  instance and pick up appropriate values from the actions environment. See
+  http://docs.stackstorm.com/actions.html#common-environment-variables-available-to-the-actions
 * `auth_token` - A negotiated auth token for the StackStorm endpoint specified
   in base_url. Note that this value will expire per the `token_ttl` specified
   in StackStorm configuration. See http://docs.stackstorm.com/authentication.html#usage

--- a/packs/st2/README.md
+++ b/packs/st2/README.md
@@ -10,6 +10,10 @@ Requires StackStorm >= `v0.8.0`
   ``http://localhost``). If only the base URL is provided, the client will
   assume default ports for the API servers are used. If any of the API server
   URL is provided, it will override the base URL and default port.
+* `auth_token` - A negotiated auth token for the StackStorm endpoint specified
+  in base_url. Note that this value will expire per the `token_ttl` specified
+  in StackStorm configuration. See http://docs.stackstorm.com/authentication.html#usage
+  on help to generate a token.
 
 ## Actions
 

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -1,4 +1,5 @@
 import os
+from six.moves import urllib_parse
 
 from st2actions.runners.pythonrunner import Action
 from st2client.client import Client
@@ -20,20 +21,21 @@ class St2BaseAction(Action):
         self.client = self._get_client()
 
     def _get_client(self):
-        base_url = self._get_base_url()
+        base_url, api_url = self._get_st2_urls()
         token = self._get_auth_token()
-        return self._client(base_url=base_url, token=token)
+        return self._client(base_url=base_url, api_url=api_url, token=token)
 
-    def _get_base_url(self):
+    def _get_st2_urls(self):
         # First try to use base_url from config.
         base_url = self.config.get('base_url', None)
+        api_url = None
 
         # not found look up from env vars. Assuming the pack is
         # configuered to work with current StackStorm instance.
         if not base_url:
-            base_url = os.environ.get('ST2_ACTION_API_URL', None)
+            api_url = os.environ.get('ST2_ACTION_API_URL', None)
 
-        return base_url
+        return base_url, api_url
 
     def _get_auth_token(self):
         # First try to use auth_token from config.

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -21,17 +21,30 @@ class St2BaseAction(Action):
         self.auth_token = self._get_auth_token()
 
     def _get_client(self):
-        host = self.config['base_url']
+        host = self._get_base_url()
 
         try:
             return self._client(base_url=host)
         except Exception as e:
             return e
 
+    def _get_base_url(self):
+        # First try to use base_url from config.
+        base_url = self.config.get('base_url', None)
+
+        # not found look up from env vars. Assuming the pack is
+        # configuered to work with current StackStorm instance.
+        if not base_url:
+            base_url = os.environ.get('ST2_ACTION_API_URL', None)
+
+        return base_url
+
     def _get_auth_token(self):
         # First try to use auth_token from config.
         token = self.config.get('auth_token', None)
 
+        # not found look up from env vars. Assuming the pack is
+        # configuered to work with current StackStorm instance.
         if not token:
             token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
 

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -18,15 +18,11 @@ class St2BaseAction(Action):
         self._client = Client
         self._kvp = KeyValuePair
         self.client = self._get_client()
-        self.auth_token = self._get_auth_token()
 
     def _get_client(self):
-        host = self._get_base_url()
-
-        try:
-            return self._client(base_url=host)
-        except Exception as e:
-            return e
+        base_url = self._get_base_url()
+        token = self._get_auth_token()
+        return self._client(base_url=base_url, token=token)
 
     def _get_base_url(self):
         # First try to use base_url from config.
@@ -50,7 +46,6 @@ class St2BaseAction(Action):
 
         return token
 
-
     def _run_client_method(self, method, method_kwargs, format_func):
         """
         Run the provided client method and format the result.
@@ -69,8 +64,6 @@ class St2BaseAction(Action):
         # Filter out parameters with string value of "None"
         # This is a work around since the default values can only be strings
         method_kwargs = filter_none_values(method_kwargs)
-        if self.auth_token:
-            method_kwargs['token'] = self.auth_token
         method_name = method.__name__
         self.logger.debug('Calling client method "%s" with kwargs "%s"' % (method_name,
                                                                            method_kwargs))

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -1,5 +1,4 @@
 import os
-from six.moves import urllib_parse
 
 from st2actions.runners.pythonrunner import Action
 from st2client.client import Client

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -1,3 +1,5 @@
+import os
+
 from st2actions.runners.pythonrunner import Action
 from st2client.client import Client
 from st2client.models.keyvalue import KeyValuePair  # pylint: disable=no-name-in-module
@@ -16,6 +18,9 @@ class St2BaseAction(Action):
         self._client = Client
         self._kvp = KeyValuePair
         self.client = self._get_client()
+        # pick up auth token from the environment. This is ofcourse assuming
+        # that base_url provided in config is configuered to match.
+        self.auth_token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
 
     def _get_client(self):
         host = self.config['base_url']
@@ -43,6 +48,8 @@ class St2BaseAction(Action):
         # Filter out parameters with string value of "None"
         # This is a work around since the default values can only be strings
         method_kwargs = filter_none_values(method_kwargs)
+        if self.auth_token:
+            method_kwargs['token'] = self.auth_token
         method_name = method.__name__
         self.logger.debug('Calling client method "%s" with kwargs "%s"' % (method_name,
                                                                            method_kwargs))

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -18,9 +18,7 @@ class St2BaseAction(Action):
         self._client = Client
         self._kvp = KeyValuePair
         self.client = self._get_client()
-        # pick up auth token from the environment. This is ofcourse assuming
-        # that base_url provided in config is configuered to match.
-        self.auth_token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
+        self.auth_token = self._get_auth_token()
 
     def _get_client(self):
         host = self.config['base_url']
@@ -29,6 +27,16 @@ class St2BaseAction(Action):
             return self._client(base_url=host)
         except Exception as e:
             return e
+
+    def _get_auth_token(self):
+        # First try to use auth_token from config.
+        token = self.config.get('auth_token', None)
+
+        if not token:
+            token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
+
+        return token
+
 
     def _run_client_method(self, method, method_kwargs, format_func):
         """

--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -1,2 +1,5 @@
 ---
   base_url: "http://localhost"
+  # auth_token will expire per token_ttl specifed in stackstorm
+  # configuration and will require a refresh.
+  auth_token: ""


### PR DESCRIPTION
Support for auth tokens and some other cleanup

* auth token can be provided in config.yaml as `auth_token` property. If not provided will be picked up from action environment variable
* `base_url` for stackstorm is picked up from config. If not provided `ST2_ACTION_API_URL` provided in action environment variable will be used. If the `st2` pack is meant to be used to work with the current stackstorm install it is better to leave base_url empty.
* Some other cleanup to un-handle exceptions in creation of client objects. Better to throw so the action fails fast.