### PR TITLE
Fix serialization issue in the IMAP sensor

### DIFF
--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -1,6 +1,7 @@
 import hashlib
 import base64
 
+import six
 import eventlet
 import easyimap
 from flanker import mime
@@ -128,7 +129,7 @@ class IMAPSensor(PollingSensor):
         has_attachments = bool(message.attachments)
 
         # Flatten the headers so they can be unpickled
-        headers = [list(header) for header in headers]
+        headers = self._flattern_headers(headers=headers)
 
         payload = {
             'uid': uid,
@@ -193,3 +194,19 @@ class IMAPSensor(PollingSensor):
         key = '%s-%s' % (message.uid, file_name)
         key = 'attachments-%s' % (hashlib.md5(key).hexdigest())
         return key
+
+    def _flattern_headers(self, headers):
+        # Flattern headers and make sure they only contain simple types so they
+        # can be serialized in a trigger
+        result = []
+
+        for pair in headers:
+            name = pair[0]
+            value = pair[1]
+
+            if not isinstance(value, six.string_types):
+                value = str(value)
+
+            result.append([name, value])
+
+        return result

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -127,6 +127,9 @@ class IMAPSensor(PollingSensor):
         headers = mime_msg.headers.items()
         has_attachments = bool(message.attachments)
 
+        # Flatten the headers so they can be unpickled
+        headers = [list(header) for header in headers]
+
         payload = {
             'uid': uid,
             'from': sent_from,


### PR DESCRIPTION
This pull request fixes #254.

The problem was that `headers` list variable items contained a class instance which wasn't available to the trigger consumers (e.g. rules engine) so de-serializing (unpickling) the payload would fail and throw an exception.

The fix is simple - I simply flatten the list and make sure each headers item (tuple) is a list.