### PR TITLE
Rule to restart hubot every 24 hours

### DIFF
--- a/packs/hubot/rules/restart_hubot.yaml
+++ b/packs/hubot/rules/restart_hubot.yaml
@@ -1,0 +1,18 @@
+---
+action:
+  parameters:
+    cmd: service hubot restart
+    sudo: true
+  ref: core.local
+criteria: {}
+description: Restart local hubot instance.
+enabled: false
+name: restart_hubot
+pack: hubot
+trigger:
+  parameters:
+    timezone: UTC
+    hour: 1
+    minute: 0
+    second: 0
+  type: core.st2.CronTimer


### PR DESCRIPTION
* Hubot teardown and bring up can be necessary so a rule to help with that every 24hours