### PR TITLE
Fix empty token in config [github]

### DIFF
--- a/packs/github/sensors/github_repository_sensor.py
+++ b/packs/github/sensors/github_repository_sensor.py
@@ -34,7 +34,7 @@ class GithubRepositorySensor(PollingSensor):
         self._last_event_ids = {}
 
     def setup(self):
-        self._client = Github(self._config['token'])
+        self._client = Github(self._config['token'] or None)
 
         for repository_dict in self._config['repository_sensor']['repositories']:
             user = self._client.get_user(repository_dict['user'])


### PR DESCRIPTION
When [token](https://github.com/StackStorm/st2contrib/blob/master/packs/github/config.yaml#L2) is "" (by default), it's considered as a string and thereby is passed to GitHub.

Error log:
```log
./st2sensorcontainer.log:Aug  4 15:15:04 localhost st2sensorcontainer[8549]: DEBUG 140284147443664 Requester [-] GET https://api.github.com/users/armab {'Authorization': 'token (oauth token removed)', 'User-Agent': 'PyGithub/Python'} null ==> 401 {'status': '401 Unauthorized', 'content-length': '83', 'x-github-media-type': 'github.v3; format=json', 'x-content-type-options': 'nosniff', 'content-security-policy': "default-src 'none'", 'access-control-expose-headers': 'ETag, Link, X-GitHub-OTP, X-RateLimit-Limit, X-RateLimit-Remaining, X-RateLimit-Reset, X-OAuth-Scopes, X-Accepted-OAuth-Scopes, X-Poll-Interval', 'x-github-request-id': 'BCF1757A:44CE:281107F:55C0D6F5', 'strict-transport-security': 'max-age=31536000; includeSubdomains; preload', 'x-ratelimit-remaining': '55', 'server': 'GitHub.com', 'x-ratelimit-limit': '60', 'x-xss-protection': '1; mode=block', 'access-control-allow-credentials': 'true', 'date': 'Tue, 04 Aug 2015 15:15:01 GMT', 'access-control-allow-origin': '*', 'content-type': 'application/json; charset=utf-8', 'x-frame-options': 'deny', 'x-ratelimit-reset': '1438703854'} {"message":"Bad credentials","documentation_url":"https://developer.github.com/v3"}

# st2sensorcontainer --config-file=/etc/st2/st2.conf --sensor-ref=github.GithubRepositorySensor
2015-08-04 15:18:02,082 DEBUG [-] Using config files: /etc/st2/st2.conf
2015-08-04 15:18:02,084 DEBUG [-] Using logging config: /etc/st2reactor/syslog.sensorcontainer.conf
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/st2reactor/container/sensor_wrapper.py", line 466, in <module>
    obj.run()
  File "/usr/lib/python2.7/dist-packages/st2reactor/container/sensor_wrapper.py", line 325, in run
    self._sensor_instance.setup()
  File "/opt/stackstorm/packs/github/sensors/github_repository_sensor.py", line 40, in setup
    user = self._client.get_user(repository_dict['user'])
  File "/opt/stackstorm/virtualenvs/github/local/lib/python2.7/site-packages/github/MainClass.py", line 157, in get_user
    "/users/" + login
  File "/opt/stackstorm/virtualenvs/github/local/lib/python2.7/site-packages/github/Requester.py", line 169, in requestJsonAndCheck
    return self.__check(*self.requestJson(verb, url, parameters, headers, input, cnx))
  File "/opt/stackstorm/virtualenvs/github/local/lib/python2.7/site-packages/github/Requester.py", line 177, in __check
    raise self.__createException(status, responseHeaders, output)
github.GithubException.BadCredentialsException: 401 {u'documentation_url': u'https://developer.github.com/v3', u'message': u'Bad credentials'}
^C

```

Let's make it more user-friendly and less strict, so `token: ""` value is considered as `None`.