### PR TITLE
Add ReleaseEvent to GithubRepositorySensor [github]

### DIFF
--- a/packs/github/README.md
+++ b/packs/github/README.md
@@ -27,6 +27,7 @@ page.
 
 This sensor monitors Github repository for activity and dispatches a trigger
 for each repository event.
+> Note that current default poll interval requires authentication because of GitHub [rate limiting](https://developer.github.com/v3/#rate-limiting) for unauthenticated requests.
 
 Currently supported event types:
 
@@ -35,6 +36,7 @@ Currently supported event types:
 * ``IssueCommentEvent`` - Triggered when an issue comment is created.
 * ``ForkEvent`` - Triggered when a user forks a repository.
 * ``WatchEvent`` - Triggered when a user stars a repository.
+* ``ReleaseEvent`` - Triggered when new release is available. 
 
 #### github.repository_event trigger
 

--- a/packs/github/sensors/github_repository_sensor.py
+++ b/packs/github/sensors/github_repository_sensor.py
@@ -18,8 +18,9 @@ class GithubRepositorySensor(PollingSensor):
         'IssuesEvent',  # Triggered when an issue is assigned, unassigned, labeled, unlabeled,
                         # opened, closed, or reopened
         'IssueCommentEvent',  # Triggered when an issue comment is created
-        'ForkEvent',  # Triggered when a user forks a repository,
-        'WatchEvent'  # Triggered when a user stars a repository
+        'ForkEvent',    # Triggered when a user forks a repository,
+        'WatchEvent',   # Triggered when a user stars a repository
+        'ReleaseEvent', # Triggered when new release is available
     ]
 
     def __init__(self, sensor_service, config=None, poll_interval=None):

--- a/packs/github/sensors/github_repository_sensor.py
+++ b/packs/github/sensors/github_repository_sensor.py
@@ -15,12 +15,12 @@ DATE_FORMAT_STRING = '%Y-%m-%d %H:%M:%S'
 
 class GithubRepositorySensor(PollingSensor):
     EVENT_TYPE_WHITELIST = [
-        'IssuesEvent',  # Triggered when an issue is assigned, unassigned, labeled, unlabeled,
-                        # opened, closed, or reopened
+        'IssuesEvent',   # Triggered when an issue is assigned, unassigned, labeled, unlabeled,
+                         # opened, closed, or reopened
         'IssueCommentEvent',  # Triggered when an issue comment is created
-        'ForkEvent',    # Triggered when a user forks a repository,
-        'WatchEvent',   # Triggered when a user stars a repository
-        'ReleaseEvent', # Triggered when new release is available
+        'ForkEvent',     # Triggered when a user forks a repository,
+        'WatchEvent',    # Triggered when a user stars a repository
+        'ReleaseEvent',  # Triggered when new release is available
     ]
 
     def __init__(self, sensor_service, config=None, poll_interval=None):

--- a/packs/github/sensors/github_repository_sensor.yaml
+++ b/packs/github/sensors/github_repository_sensor.yaml
@@ -2,6 +2,8 @@
   class_name: "GithubRepositorySensor"
   entry_point: "github_repository_sensor.py"
   description: "Sensor which monitors Github repository for activity"
+  # requires authentication because of GitHub rate limiting
+  # use default with auth or increase poll interval
   poll_interval: 30
   trigger_types:
     -


### PR DESCRIPTION
Adds ability to monitor GitHub repository releases via [`ReleaseEvent`](https://developer.github.com/v3/activity/events/types/#releaseevent).

/cc @Kami for making it easy :+1: 