### PR TITLE
Bump `gitpython` in Git Pack

### DIFF
--- a/packs/git/requirements.txt
+++ b/packs/git/requirements.txt
@@ -1,1 +1,1 @@
-gitpython==0.3.2RC1
+gitpython==1.0.1


### PR DESCRIPTION
During troubleshooting yesterday, we found that an older version of `gitpython` is causing an inability to clone repos from GitHub Enterprise. Bumping to latest version resolves this.