### PR TITLE
Initial ServiceNow integration

### DIFF
--- a/packs/servicenow/README.md
+++ b/packs/servicenow/README.md
@@ -4,7 +4,7 @@ This integration allows bi-directional communication between StackStorm and Serv
 
 # Overview
 
-This action provides the basic REST primitaves necessary to allow communication between StackStorm and ServiceNow. Ideally, this integration will be consumed in a site-specific integration pack that defines actions to specific ServiceNow specific business logic.
+This action provides the basic REST primitives necessary to allow communication between StackStorm and ServiceNow. Ideally, this integration will be consumed in a site-specific integration pack that defines actions to specific ServiceNow specific business logic.
 
 ServiceNow provides two videos to demonstrate how to setup Inbound and Outbound Web Service integrations.
 

--- a/packs/servicenow/README.md
+++ b/packs/servicenow/README.md
@@ -16,9 +16,21 @@ An example pack has been included in this pack to show the integration of Servic
 # Setup
 ## Configuration
 
+### Outgoing Integration
+
 * `instance_name` - Upstream Instance Name (e.x.: stackstorm)
 * `username` - Username of service account
 * `password` - Password of service account
+
+### Incoming Integration
+
+In your ServiceNow Outbound integration, REST endpoints accept JSON payloads. In addition, you must specify the following headers in your payload request:
+
+```
+Accept: application/json
+Content-Type: application/json
+```
+
 
 ## Actions
 

--- a/packs/servicenow/README.md
+++ b/packs/servicenow/README.md
@@ -1,0 +1,28 @@
+# ServiceNow Integration Pack
+
+This integration allows bi-directional communication between StackStorm and ServiceNow REST API
+
+# Overview
+
+This action provides the basic REST primitaves necessary to allow communication between StackStorm and ServiceNow. Ideally, this integration will be consumed in a site-specific integration pack that defines actions to specific ServiceNow specific business logic.
+
+ServiceNow provides two videos to demonstrate how to setup Inbound and Outbound Web Service integrations.
+
+* Inbound Integration - https://www.youtube.com/watch?v=EhxgEECd7mQ
+* Outbound Integration - https://www.youtube.com/watch?v=WeeDW_iRM8k
+
+An example pack has been included in this pack to show the integration of ServiceNow with these two integration examples.
+
+# Setup
+## Configuration
+
+* `instance_name` - Upstream Instance Name (e.x.: stackstorm)
+* `username` - Username of service account
+* `password` - Password of service account
+
+## Actions
+
+* `servicenow.get` - Get an entry from a ServiceNow Table
+* `servicenow.update` - Update an entry in a ServiceNow Table
+* `servicenow.insert` - Insert an entry to a ServiceNow Table
+* `servicenow.delete` - Delete an entry from a ServiceNow Table

--- a/packs/servicenow/actions/README.md
+++ b/packs/servicenow/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/servicenow/actions/delete.py
+++ b/packs/servicenow/actions/delete.py
@@ -4,5 +4,5 @@ from lib.actions import BaseAction
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
         self.client.table = table  # pylint: disable=no-member
-        response = self.client.delete(sysid)
+        response = self.client.delete(sysid)  # pylint: disable=no-member
         return response

--- a/packs/servicenow/actions/delete.py
+++ b/packs/servicenow/actions/delete.py
@@ -3,9 +3,6 @@ from lib.actions import BaseAction
 
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
-        try:
-            self.client.table = table
-            response = self.client.delete(sysid)
-            return response
-        except e:
-            raise e
+        self.client.table = table
+        response = self.client.delete(sysid)
+        return response

--- a/packs/servicenow/actions/delete.py
+++ b/packs/servicenow/actions/delete.py
@@ -3,8 +3,6 @@ from lib.actions import BaseAction
 
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
-        self.client.table = table
-        # pylint: disable=no-member
-
+        self.client.table = table  # pylint: disable=no-member
         response = self.client.delete(sysid)
         return response

--- a/packs/servicenow/actions/delete.py
+++ b/packs/servicenow/actions/delete.py
@@ -4,5 +4,7 @@ from lib.actions import BaseAction
 class DeleteAction(BaseAction):
     def run(self, table, sysid):
         self.client.table = table
+        # pylint: disable=no-member
+
         response = self.client.delete(sysid)
         return response

--- a/packs/servicenow/actions/delete.py
+++ b/packs/servicenow/actions/delete.py
@@ -1,0 +1,11 @@
+from lib.actions import BaseAction
+
+
+class DeleteAction(BaseAction):
+    def run(self, table, sysid):
+        try:
+            self.client.table = table
+            response = self.client.delete(sysid)
+            return response
+        except e:
+            raise e

--- a/packs/servicenow/actions/delete.yaml
+++ b/packs/servicenow/actions/delete.yaml
@@ -1,0 +1,15 @@
+---
+name: "delete"
+runner_type: "python-script"
+description: "Delete an entry from a ServiceNow Table"
+enabled: true
+entry_point: "delete.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  sysid:
+    type: "string"
+    description: "ID of record"
+    required: true

--- a/packs/servicenow/actions/get.py
+++ b/packs/servicenow/actions/get.py
@@ -3,8 +3,6 @@ from lib.actions import BaseAction
 
 class GetAction(BaseAction):
     def run(self, table, query):
-        self.client.table = table
-        # pylint: disable=no-member
-
+        self.client.table = table  # pylint: disable=no-member
         response = self.client.get(query)
         return response

--- a/packs/servicenow/actions/get.py
+++ b/packs/servicenow/actions/get.py
@@ -4,5 +4,5 @@ from lib.actions import BaseAction
 class GetAction(BaseAction):
     def run(self, table, query):
         self.client.table = table  # pylint: disable=no-member
-        response = self.client.get(query)
+        response = self.client.get(query)  # pylint: disable=no-member
         return response

--- a/packs/servicenow/actions/get.py
+++ b/packs/servicenow/actions/get.py
@@ -3,9 +3,6 @@ from lib.actions import BaseAction
 
 class GetAction(BaseAction):
     def run(self, table, query):
-        try:
-            self.client.table = table
-            response = self.client.get(query)
-            return response
-        except e:
-            raise e
+        self.client.table = table
+        response = self.client.get(query)
+        return response

--- a/packs/servicenow/actions/get.py
+++ b/packs/servicenow/actions/get.py
@@ -1,0 +1,11 @@
+from lib.actions import BaseAction
+
+
+class GetAction(BaseAction):
+    def run(self, table, query):
+        try:
+            self.client.table = table
+            response = self.client.get(query)
+            return response
+        except e:
+            raise e

--- a/packs/servicenow/actions/get.py
+++ b/packs/servicenow/actions/get.py
@@ -4,5 +4,7 @@ from lib.actions import BaseAction
 class GetAction(BaseAction):
     def run(self, table, query):
         self.client.table = table
+        # pylint: disable=no-member
+
         response = self.client.get(query)
         return response

--- a/packs/servicenow/actions/get.yaml
+++ b/packs/servicenow/actions/get.yaml
@@ -1,0 +1,15 @@
+---
+name: "get"
+runner_type: "python-script"
+description: "Get an entry from a ServiceNow Table"
+enabled: true
+entry_point: "get.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  query:
+    type: "object"
+    description: "Structured query for SN data"
+    required: true

--- a/packs/servicenow/actions/insert.py
+++ b/packs/servicenow/actions/insert.py
@@ -4,5 +4,5 @@ from lib.actions import BaseAction
 class InsertAction(BaseAction):
     def run(self, table, payload):
         self.client.table = table  # pylint: disable=no-member
-        response = self.client.insert(payload)
+        response = self.client.insert(payload)  # pylint: disable=no-member
         return response

--- a/packs/servicenow/actions/insert.py
+++ b/packs/servicenow/actions/insert.py
@@ -4,5 +4,7 @@ from lib.actions import BaseAction
 class InsertAction(BaseAction):
     def run(self, table, payload):
         self.client.table = table
+        # pylint: disable=no-member
+
         response = self.client.insert(payload)
         return response

--- a/packs/servicenow/actions/insert.py
+++ b/packs/servicenow/actions/insert.py
@@ -3,8 +3,6 @@ from lib.actions import BaseAction
 
 class InsertAction(BaseAction):
     def run(self, table, payload):
-        self.client.table = table
-        # pylint: disable=no-member
-
+        self.client.table = table  # pylint: disable=no-member
         response = self.client.insert(payload)
         return response

--- a/packs/servicenow/actions/insert.py
+++ b/packs/servicenow/actions/insert.py
@@ -1,0 +1,11 @@
+from lib.actions import BaseAction
+
+
+class InsertAction(BaseAction):
+    def run(self, table, payload):
+        try:
+            self.client.table = table
+            response = self.client.insert(payload)
+            return response
+        except e:
+            raise e

--- a/packs/servicenow/actions/insert.py
+++ b/packs/servicenow/actions/insert.py
@@ -3,9 +3,6 @@ from lib.actions import BaseAction
 
 class InsertAction(BaseAction):
     def run(self, table, payload):
-        try:
-            self.client.table = table
-            response = self.client.insert(payload)
-            return response
-        except e:
-            raise e
+        self.client.table = table
+        response = self.client.insert(payload)
+        return response

--- a/packs/servicenow/actions/insert.yaml
+++ b/packs/servicenow/actions/insert.yaml
@@ -1,0 +1,15 @@
+---
+name: "insert"
+runner_type: "python-script"
+description: "Insert an entry to a ServiceNow Table"
+enabled: true
+entry_point: "insert.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  payload:
+    type: "object"
+    description: "Data to upload to ServiceNow"
+    required: true

--- a/packs/servicenow/actions/lib/actions.py
+++ b/packs/servicenow/actions/lib/actions.py
@@ -1,0 +1,15 @@
+from st2actions.runners.pythonrunner import Action
+import servicenow_rest.api as sn
+
+
+class BaseAction(Action):
+    def __init__(self, config):
+        super(BaseAction, self).__init__(config)
+        self.client = self._get_client()
+
+    def _get_client(self):
+        instance_name = self.config['instance_name']
+        username = self.config['username']
+        password = self.config['password']
+
+        return sn.Client(instance_name, username, password)

--- a/packs/servicenow/actions/update.py
+++ b/packs/servicenow/actions/update.py
@@ -3,9 +3,6 @@ from lib.actions import BaseAction
 
 class UpdateAction(BaseAction):
     def run(self, table, query, payload, sysid):
-        try:
-            self.client.table = table
-            response = self.client.update(query, payload, sysid)
-            return response
-        except e:
-            raise e
+        self.client.table = table
+        response = self.client.update(query, payload, sysid)
+        return response

--- a/packs/servicenow/actions/update.py
+++ b/packs/servicenow/actions/update.py
@@ -4,5 +4,5 @@ from lib.actions import BaseAction
 class UpdateAction(BaseAction):
     def run(self, table, query, payload, sysid):
         self.client.table = table  # pylint: disable=no-member
-        response = self.client.update(query, payload, sysid)
+        response = self.client.update(query, payload, sysid)  # pylint: disable=no-member
         return response

--- a/packs/servicenow/actions/update.py
+++ b/packs/servicenow/actions/update.py
@@ -4,5 +4,7 @@ from lib.actions import BaseAction
 class UpdateAction(BaseAction):
     def run(self, table, query, payload, sysid):
         self.client.table = table
+        # pylint: disable=no-member
+
         response = self.client.update(query, payload, sysid)
         return response

--- a/packs/servicenow/actions/update.py
+++ b/packs/servicenow/actions/update.py
@@ -1,0 +1,11 @@
+from lib.actions import BaseAction
+
+
+class UpdateAction(BaseAction):
+    def run(self, table, query, payload, sysid):
+        try:
+            self.client.table = table
+            response = self.client.update(query, payload, sysid)
+            return response
+        except e:
+            raise e

--- a/packs/servicenow/actions/update.py
+++ b/packs/servicenow/actions/update.py
@@ -3,8 +3,6 @@ from lib.actions import BaseAction
 
 class UpdateAction(BaseAction):
     def run(self, table, query, payload, sysid):
-        self.client.table = table
-        # pylint: disable=no-member
-
+        self.client.table = table  # pylint: disable=no-member
         response = self.client.update(query, payload, sysid)
         return response

--- a/packs/servicenow/actions/update.yaml
+++ b/packs/servicenow/actions/update.yaml
@@ -1,0 +1,23 @@
+---
+name: "update"
+runner_type: "python-script"
+description: "Update an entry in a ServiceNow Table"
+enabled: true
+entry_point: "update.py"
+parameters:
+  table:
+    type: "string"
+    description: "Table to take action on"
+    required: true
+  query:
+    type: "object"
+    description: "Structured query for SN data"
+    required: true
+  payload:
+    type: "object"
+    description: "Data to upload to ServiceNow"
+    required: true
+  sysid:
+    type: "string"
+    description: "ID of record"
+    required: true

--- a/packs/servicenow/config.yaml
+++ b/packs/servicenow/config.yaml
@@ -1,0 +1,5 @@
+### Place configuration data for your pack here.
+---
+instance_name: ""
+user_name: ""
+password: ""

--- a/packs/servicenow/etc/acme_example/README.md
+++ b/packs/servicenow/etc/acme_example/README.md
@@ -1,0 +1,8 @@
+# Acme StackStorm / ServiceNow Integration
+
+This pack is an example pack showing how to consume the ServiceNow integration pack with StackStorm
+
+This pack uses the ServiceNow Outbound and Inbound Integration examples.
+
+* Inbound Integration - https://www.youtube.com/watch?v=EhxgEECd7mQ
+* Outbound Integration - https://www.youtube.com/watch?v=WeeDW_iRM8k

--- a/packs/servicenow/etc/acme_example/actions/README.md
+++ b/packs/servicenow/etc/acme_example/actions/README.md
@@ -1,0 +1,5 @@
+# actions
+
+The actions folder contains action scripts and metadata files. See [Actions](http://docs.stackstorm.com/actions.html)
+and [Workflows](http://docs.stackstorm.com/workflows.html) for specifics on writing actions. Note that the lib sub-folder
+is always available for access for an action script.

--- a/packs/servicenow/etc/acme_example/actions/post_research_item.yaml
+++ b/packs/servicenow/etc/acme_example/actions/post_research_item.yaml
@@ -1,0 +1,26 @@
+---
+name: "post_research_item"
+runner_type: "action-chain"
+description: "Post a research item to Acme queue via ServiceNow"
+enabled: true
+entry_point: "workflows/post_research_item.yaml"
+parameters:
+  assigned_to:
+    type: "string"
+    description: "Assign to user"
+    required: true
+  comment:
+    type: "string"
+    description: "Note to add to researcher"
+    required: true
+  source:
+    type: "string"
+    description: "Source of research item"
+  text:
+    type: "string"
+    description: "Information around research item"
+    required: true
+  url:
+    type: "string"
+    description: "URL to research"
+    required: true

--- a/packs/servicenow/etc/acme_example/actions/workflows/post_research_item.yaml
+++ b/packs/servicenow/etc/acme_example/actions/workflows/post_research_item.yaml
@@ -1,0 +1,10 @@
+---
+  chain:
+    -
+      name: "post_to_servicenow"
+      ref: "servicenow.insert"
+      params:
+        payload:
+          assigned_to: "Estee Tew"
+          comment: "This is a site to research about REST"
+          url: "https://en.wikipedia.org/wiki/Representational_state_transfer"

--- a/packs/servicenow/etc/acme_example/config.yaml
+++ b/packs/servicenow/etc/acme_example/config.yaml
@@ -1,0 +1,3 @@
+### Place configuration data for your pack here.
+---
+

--- a/packs/servicenow/etc/acme_example/pack.yaml
+++ b/packs/servicenow/etc/acme_example/pack.yaml
@@ -1,0 +1,7 @@
+### Place information about your pack version here.
+---
+name: acme_example
+description: Example ServiceNow integration
+version: 0.1.0
+author: James Fryman
+email: james@stackstorm.com

--- a/packs/servicenow/etc/acme_example/rules/README.md
+++ b/packs/servicenow/etc/acme_example/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/servicenow/etc/acme_example/rules/research_item.yaml
+++ b/packs/servicenow/etc/acme_example/rules/research_item.yaml
@@ -1,0 +1,13 @@
+---
+name: 'acme.research_item'
+description: "Incoming webhook integration for Acme research"
+enabled: true
+trigger:
+  type: "core.st2.webhook"
+  parameters:
+    url: "acme/research_item"
+criteria: {}
+action:
+  ref: "acme.post_action"
+  parameters:
+    correlation_id: "{{trigger.body.correlationID}}

--- a/packs/servicenow/etc/acme_example/sensors/README.md
+++ b/packs/servicenow/etc/acme_example/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensoros. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.

--- a/packs/servicenow/pack.yaml
+++ b/packs/servicenow/pack.yaml
@@ -1,0 +1,7 @@
+### Place information about your pack version here.
+---
+name: servicenow
+description: ServiceNow Integration Pack
+version: 0.1.0
+author: James Fryman
+mail: james@stackstorm.com

--- a/packs/servicenow/requirements.txt
+++ b/packs/servicenow/requirements.txt
@@ -1,0 +1,1 @@
+servicenow_rest

--- a/packs/servicenow/rules/README.md
+++ b/packs/servicenow/rules/README.md
@@ -1,0 +1,3 @@
+# rules
+
+The rules folder contains rules. See [Rules](http://docs.stackstorm.com/rules.html) for specifics on writing rules.

--- a/packs/servicenow/sensors/README.md
+++ b/packs/servicenow/sensors/README.md
@@ -1,0 +1,4 @@
+# sensors
+
+The sensors folder contains sensors. See [Sensors](http://docs.stackstorm.com/sensors.html) for specifics on writing
+sensors and registering TriggerTypes.


### PR DESCRIPTION
# ServiceNow Integration Pack

This integration allows bi-directional communication between StackStorm and ServiceNow REST API

# Overview

This action provides the basic REST primitaves necessary to allow communication between StackStorm and ServiceNow. Ideally, this integration will be consumed in a site-specific integration pack that defines actions to specific ServiceNow specific business logic.

ServiceNow provides two videos to demonstrate how to setup Inbound and Outbound Web Service integrations.

* Inbound Integration - https://www.youtube.com/watch?v=EhxgEECd7mQ
* Outbound Integration - https://www.youtube.com/watch?v=WeeDW_iRM8k

An example pack has been included in this pack to show the integration of ServiceNow with these two integration examples.

# Setup
## Configuration

* `instance_name` - Upstream Instance Name (e.x.: stackstorm)
* `username` - Username of service account
* `password` - Password of service account

## Actions

* `servicenow.get` - Get an entry from a ServiceNow Table
* `servicenow.update` - Update an entry in a ServiceNow Table
* `servicenow.insert` - Insert an entry to a ServiceNow Table
* `servicenow.delete` - Delete an entry from a ServiceNow Table