### PR TITLE
Use valid email since StackStorm now looks for a valid email.

### DIFF
--- a/packs/rackspace/pack.yaml
+++ b/packs/rackspace/pack.yaml
@@ -3,4 +3,4 @@ name: rackspace
 description: Packs which allows integration with Rackspace services such as servers, load balancers and DNS.
 version: 0.1.0
 author: jfryman
-email: jfryman@FryBook
+email: james@stackstorm.com


### PR DESCRIPTION
Since https://github.com/StackStorm/st2/blob/master/st2common/st2common/models/db/pack.py#L36

Leads to -
```
2015-08-20 01:20:17,807 ERROR [-] Failed to register pack "rackspace"
Traceback (most recent call last):
  File "/usr/lib/python2.7/dist-packages/st2common/bootstrap/base.py", line 100, in register_pack
    pack_db = self._register_pack(pack_name=pack_name, pack_dir=pack_dir)
  File "/usr/lib/python2.7/dist-packages/st2common/bootstrap/base.py", line 137, in _register_pack
    pack_db = Pack.add_or_update(pack_db)
  File "/usr/lib/python2.7/dist-packages/st2common/persistence/base.py", line 118, in add_or_update
    model_object = cls._get_impl().add_or_update(model_object)
  File "/usr/lib/python2.7/dist-packages/st2common/models/db/__init__.py", line 134, in add_or_update
    instance.save()
  File "/usr/local/lib/python2.7/dist-packages/mongoengine/document.py", line 224, in save
    self.validate(clean=clean)
  File "/usr/local/lib/python2.7/dist-packages/mongoengine/base/document.py", line 323, in validate
    raise ValidationError(message, errors=errors)
ValidationError: ValidationError (PackDB:None) (Invalid Mail-address: jfryman@FryBook: ['email'])
```