### PR TITLE
Changing issue number in "github" pack to string to allow evaluation

### DIFF
--- a/packs/github/actions/add_comment.yaml
+++ b/packs/github/actions/add_comment.yaml
@@ -14,7 +14,7 @@
       description: "Repository name."
       required: true
     issue:
-      type: "integer"
+      type: "string"
       description: "Issue / pull request number"
       required: true
     body:

--- a/packs/github/actions/get_issue.yaml
+++ b/packs/github/actions/get_issue.yaml
@@ -14,6 +14,6 @@ parameters:
     description: "Repository name."
     required: true
   issue_id:
-    type: integer
+    type: "string"
     description: Issue id
     required: true


### PR DESCRIPTION
This was reported in st2web issues: https://github.com/StackStorm/st2web/issues/184
Changing validation type to string solves the problem, and I imagine that's a pretty common use case.