### PR TITLE
[octopusdeploy] Replace `run-python` with `python-script` runner_type

### DIFF
--- a/packs/octopusdeploy/README.md
+++ b/packs/octopusdeploy/README.md
@@ -1,7 +1,8 @@
 # Octopus Deploy Integration Pack
 
 This integration pack allows you to integrate with
-[Octopus Deploy](http://octopusdeploy.com/).
+[Octopus Deploy](http://octopusdeploy.com/),
+deployment automation system for .NET applications.
 
 ## Actions
 
@@ -17,6 +18,6 @@ Currently, the following actions listed bellow are supported:
 
 Update config.yaml to setup the connection to Octopus.
 
-* api_key - an API key generated in Octopus for your user http://docs.octopusdeploy.com/display/OD/How+to+create+an+API+key 
-* host - the hostname of your Octopus server e.g. octopus.mydomain.com
-* port - the port your API service is running on, 443 by default
+* `api_key` - an API key generated in Octopus for your user http://docs.octopusdeploy.com/display/OD/How+to+create+an+API+key 
+* `host` - the hostname of your Octopus server e.g. octopus.mydomain.com
+* `port` - the port your API service is running on, 443 by default

--- a/packs/octopusdeploy/actions/create_release.yaml
+++ b/packs/octopusdeploy/actions/create_release.yaml
@@ -1,6 +1,6 @@
 ---
 name: create_release
-runner_type: run-python
+runner_type: python-script
 description: Create a new release in Octopus.
 enabled: true
 entry_point: create_release.py

--- a/packs/octopusdeploy/actions/deploy_release.yaml
+++ b/packs/octopusdeploy/actions/deploy_release.yaml
@@ -1,6 +1,6 @@
 ---
 name: deploy_release
-runner_type: run-python
+runner_type: python-script
 description: Deploy a release in Octopus.
 enabled: true
 entry_point: deploy_release.py

--- a/packs/octopusdeploy/actions/get_releases.yaml
+++ b/packs/octopusdeploy/actions/get_releases.yaml
@@ -1,6 +1,6 @@
 ---
 name: get_releases
-runner_type: run-python
+runner_type: python-script
 description: Get a list of releases for a project in Octopus.
 enabled: true
 entry_point: get_releases.py


### PR DESCRIPTION
`run-python` runner type is [outdated naming](https://github.com/StackStorm/st2/blob/master/docs/source/upgrade_notes.rst#st2-09).
It will work because of [backward compatibility](https://github.com/StackStorm/st2/blob/badabcb2039dba32fe75e9e5cf7ce03e17f6c350/st2actions/st2actions/bootstrap/runnersregistrar.py#L357), but it's better to replace with `python-script` for consistency and less confusion in future.

http://docs.stackstorm.com/actions.html?highlight=runner_type#available-runners

---

cc @tonybaloney it's really clean & nice pack!