### PR TITLE
Update channel -> route

### DIFF
--- a/packs/hubot/rules/notify_hubot.yaml
+++ b/packs/hubot/rules/notify_hubot.yaml
@@ -7,7 +7,7 @@ trigger:
   pack: "chatops"
   type: "core.st2.generic.notifytrigger"
 criteria:
-  trigger.routes:
+  trigger.route:
     pattern: "hubot"
     type: "equals"
 action:

--- a/packs/hubot/rules/notify_hubot.yaml
+++ b/packs/hubot/rules/notify_hubot.yaml
@@ -7,7 +7,7 @@ trigger:
   pack: "chatops"
   type: "core.st2.generic.notifytrigger"
 criteria:
-  trigger.channel:
+  trigger.routes:
     pattern: "hubot"
     type: "equals"
 action:


### PR DESCRIPTION
This PR updates the rule in `notify_hubot` to use the updated `routes` vernacular. 