### PR TITLE
[trello] TrelloListSensor improvements

### DIFF
--- a/packs/trello/CHANGES.md
+++ b/packs/trello/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+* Added `TrelloListSensor` which monitors Trello List(s) for new actions/changes
+
 ## v0.1.1
 
 * Added optional `description` parameter to `trello.add_card` action

--- a/packs/trello/README.md
+++ b/packs/trello/README.md
@@ -49,20 +49,35 @@ To obtain an oAuth token, refer to the documentation at https://trello.com/docs/
 
 ## Sensors
 ### TrelloListSensor
-Listens for the new Actions in Trello List, which is specified via [config](config.yaml), and dispatches trigger for each new event occurred.
+Listens for the new Actions (changes) in Trello List(s) and dispatches trigger for each new event occurred.
 
-Optionally you can specify in config which actions to listen via `filter` parameter.
+#### Config
+Parameters in `list_actions_sensor` for every trello list:
+* `list_id` - Trello List ID we monitor for new actions (required)
+* `board_id` - Board ID where Trello List is located (required)
+* `api_key` - Trello API key (optional)
+* `token` - Trello API token (optional)
+* `filter` - Filter actions by type(s) (eg. createCard, deleteCard) (optional)
+
 For list of available filters see [Trello API docs](https://trello.com/docs/api/list/index.html#get-1-lists-idlist-actions).
 
-When receives new data, Sensor emits:
+> API credentials work at any level with lower priority for top-level config credentials:
+`list config` > `lists config` > `global config`.
+It means that every Trello list can have its own unique credentials to work with different accounts.
+
+See [config](config.yaml) for more examples.
+Keep in mind, that Sensor with invalid config (bad credentials) will die after 3 connection retries.
+
+#### Output
+When `TrelloListSensor` receives new data, it emits:
 * trigger: `trello.new_action`
-* returns data:
-  * `payload.id` - Action ID (string)
-  * `payload.data` - Main data returned, specific for action, depends on action type (object)
-  * `payload.date` - When action occurred (string)
-  * `payload.idMemberCreator` - User ID who initiated the action (string)
-  * `payload.type` - Action type (ex: createCard) (string)
-  * `payload.memberCreator` - Extended info about user who initiated action (object)
+* and returns data:
+  * `trigger.id` - Action ID (string)
+  * `trigger.data` - Main data returned, specific for action, depends on action type (object)
+  * `trigger.date` - When action occurred (string)
+  * `trigger.idMemberCreator` - User ID who initiated the action (string)
+  * `trigger.type` - Action type (ex: createCard) (string)
+  * `trigger.memberCreator` - Extended info about user who initiated action (object)
 
 
 ## Examples

--- a/packs/trello/README.md
+++ b/packs/trello/README.md
@@ -79,6 +79,35 @@ When `TrelloListSensor` receives new data, it emits:
   * `trigger.type` - Action type (ex: createCard) (string)
   * `trigger.memberCreator` - Extended info about user who initiated action (object)
 
+Example:
+```json
+{
+    "id": "4efe3147c72846af4e00006d",
+    "data": {
+        "list": {
+            "id": "4eea4ffc91e31d174600004a",
+            "name": "To Do Later"
+        },
+        "board": {
+            "id": "4eea4ffc91e31d1746000046",
+            "name": "Example Board"
+        },
+        "old": {
+            "name": "To Do Eventually"
+        }
+    },
+    "date": "2011-12-30T21:46:47.843Z",
+    "idMemberCreator": "4ee7deffe582acdec80000ac",
+    "type": "updateList",
+    "memberCreator": {
+        "id": "4ee7deffe582acdec80000ac",
+        "avatarHash": null,
+        "fullName": "Joe Tester",
+        "initials": "JT",
+        "username": "joetester"
+    }
+}
+```
 
 ## Examples
 > Note that every action has structurised output, meaning you can use returned results in action chains.

--- a/packs/trello/README.md
+++ b/packs/trello/README.md
@@ -47,6 +47,24 @@ To obtain an oAuth token, refer to the documentation at https://trello.com/docs/
 +---------------------------+--------+--------------------+------------------------------------------------------+
 ```
 
+## Sensors
+### TrelloListSensor
+Listens for the new Actions in Trello List, which is specified via [config](config.yaml), and dispatches trigger for each new event occurred.
+
+Optionally you can specify in config which actions to listen via `filter` parameter.
+For list of available filters see [Trello API docs](https://trello.com/docs/api/list/index.html#get-1-lists-idlist-actions).
+
+When receives new data, Sensor emits:
+* trigger: `trello.new_action`
+* returns data:
+  * `payload.id` - Action ID (string)
+  * `payload.data` - Main data returned, specific for action, depends on action type (object)
+  * `payload.date` - When action occurred (string)
+  * `payload.idMemberCreator` - User ID who initiated the action (string)
+  * `payload.type` - Action type (ex: createCard) (string)
+  * `payload.memberCreator` - Extended info about user who initiated action (object)
+
+
 ## Examples
 > Note that every action has structurised output, meaning you can use returned results in action chains.
 

--- a/packs/trello/config.yaml
+++ b/packs/trello/config.yaml
@@ -3,7 +3,16 @@
   token: ""
 
   list_actions_sensor:
-    board_id: c39TEFLt
-    list_id: 55e7456df81e21e9b4aea429
-    filter:
-      - createCard
+    #api_key: ""
+    #token: ""
+    lists:
+    - list_id: 55e7456df81e21e9b4aea429
+      board_id: c39TEFLt
+      #api_key: ""
+      #token: ""
+
+    - list_id: 55f95fc7f6352543770088be
+      board_id: c39TEFLt
+      filter:
+        - updateCard
+        - deleteCard

--- a/packs/trello/pack.yaml
+++ b/packs/trello/pack.yaml
@@ -1,8 +1,7 @@
-### Place information about your pack version here.
 ---
 name: trello
 description: Integration with Trello, Web based Project Management
-version: 0.1.1
+version: 0.2.0
 author: James Fryman
 email: james@stackstorm.com
 keywords:

--- a/packs/trello/sensors/list_actions_sensor.yaml
+++ b/packs/trello/sensors/list_actions_sensor.yaml
@@ -9,14 +9,38 @@ trigger_types:
     payload_schema:
       type: object
       properties:
-        data:
-          type: object
-        idMemberCreator:
+        id:
+          description: "Unique action ID"
           type: string
-        memberCreator:
+        data:
+          description: "Structurized data returned for action, depends on action type"
           type: object
         date:
+          description: "When action occurred"
           type: string
-          #format: 2015-09-02T18:53:30.900Z
-        id:
+          format: date-time
+        idMemberCreator:
+          description: "User ID who initiated the action"
           type: string
+        type:
+          description: "Action type (ex: createCard)"
+          type: string
+        memberCreator:
+          description: "Additional info about user who initiated action"
+          type: object
+          properties:
+            id:
+              description: "User ID"
+              type: string
+            avatarHash:
+              description: "Avatar hash (md5)"
+              type: string
+            fullName:
+              description: "User's full name"
+              type: string
+            initials:
+              description: "User's initials"
+              type: string
+            username:
+              description: "Username"
+              type: string


### PR DESCRIPTION
Improves `TrelloListSensor` #291  implementation, - sensor which monitors Trello List for new actions (new Trello card is created, edited, deleted, etc).

* [x] Ability to monitor several Trello Lists
* [x] Every monitored Trello List can use its own API credentials (work with many Trello accounts)
* [x] API credentials precedence: `list config` > `lists config` > `global config` (global config is less significant)
* [x] [Parameters descriptions for `payload_schema`](https://github.com/StackStorm/st2contrib/pull/292/files#diff-ccfcafb9de5144a242c9c39721040ab4R11) (autocomplete hints in webui)
* [x] Better documentation for `TrelloListSensor`
* [x] Monkey (manual) testing

![1](https://cloud.githubusercontent.com/assets/1533818/9917429/6d81e182-5cb9-11e5-8d02-263722440173.gif)
