### PR TITLE
Remove default base_url value

### DIFF
--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -1,5 +1,5 @@
 ---
-base_url: "http://localhost"
+base_url: ""
 # auth_token will expire per token_ttl specifed in stackstorm
 # configuration and will require a refresh.
 auth_token: ""


### PR DESCRIPTION
* For local stackstorm better to pick from env vars of action

Testing -
* Validated in a setup with and without auth etc. With value filled in for base_url and value inferred from environment vars.