### PR TITLE
Update st2.upload_to_s3 action so it can upload to any publicly writable S3 bucket, remove AWS credentials from config

### DIFF
--- a/packs/st2/actions/upload_to_s3.py
+++ b/packs/st2/actions/upload_to_s3.py
@@ -1,21 +1,51 @@
+import os
+import httplib
+
+import requests
+
 from lib.action import St2BaseAction
-import s3
 
 __all__ = [
     'UploadToS3'
 ]
 
+S3_BUCKET_URL = 'https://%(bucket)s.s3.amazonaws.com/'
+
 
 class UploadToS3(St2BaseAction):
-    def run(self, file_name, remote_file, bucket):
-        remote_name = s3.S3Name(remote_file, bucket=bucket)
+    """
+    Note: The destination bucket me be configured so everyone can write to it,
+    but only we can read from it.
+    """
 
-        connection = s3.S3Connection(**self.config['s3'])
-        storage = s3.Storage(connection)
-        storage.write(file_name, remote_name)
-        payload = {
-            "status": "ok",
-            "uploaded_file": remote_file,
+    def run(self, bucket, file_name, remote_file=None):
+        if not remote_file:
+            remote_file = os.path.basename(remote_file)
+
+        if not os.path.isfile(file_name):
+            raise ValueError('Local file "%s" doesn\'t exist' % (file_name))
+
+        url = S3_BUCKET_URL % {'bucket': bucket}
+        url = url + remote_file
+
+        # Note: Requests library performs streaming and chunked upload
+        files = {'file': open(file_name, 'rb')}
+        response = requests.put(url=url, files=files, verify=False)
+
+        if response.status_code in [httplib.OK, httplib.CREATED]:
+            status = 'ok'
+            error = None
+        else:
+            status = 'failure'
+            error = response.text
+
+        result = {
+            'status_code': response.status_code,
+            'status': status,
+            'uploaded_file': remote_file,
         }
 
-        return payload
+        if error:
+            result['error'] = error
+
+        return result

--- a/packs/st2/actions/upload_to_s3.py
+++ b/packs/st2/actions/upload_to_s3.py
@@ -14,7 +14,7 @@ S3_BUCKET_URL = 'https://%(bucket)s.s3.amazonaws.com/'
 
 class UploadToS3(St2BaseAction):
     """
-    Note: The destination bucket me be configured so everyone can write to it,
+    Note: The destination bucket must be configured so everyone can write to it,
     but only we can read from it.
     """
 

--- a/packs/st2/actions/upload_to_s3.py
+++ b/packs/st2/actions/upload_to_s3.py
@@ -30,7 +30,7 @@ class UploadToS3(St2BaseAction):
 
         # Note: Requests library performs streaming and chunked upload
         files = {'file': open(file_name, 'rb')}
-        response = requests.put(url=url, files=files, verify=False)
+        response = requests.put(url=url, files=files)
 
         if response.status_code in [httplib.OK, httplib.CREATED]:
             status = 'ok'

--- a/packs/st2/actions/upload_to_s3.py
+++ b/packs/st2/actions/upload_to_s3.py
@@ -20,7 +20,7 @@ class UploadToS3(St2BaseAction):
 
     def run(self, bucket, file_name, remote_file=None):
         if not remote_file:
-            remote_file = os.path.basename(remote_file)
+            remote_file = os.path.basename(file_name)
 
         if not os.path.isfile(file_name):
             raise ValueError('Local file "%s" doesn\'t exist' % (file_name))

--- a/packs/st2/actions/upload_to_s3.yaml
+++ b/packs/st2/actions/upload_to_s3.yaml
@@ -11,8 +11,8 @@ parameters:
     required: true
   remote_file:
     type: "string"
-    description: "Name of file on remote end"
-    required: true
+    description: "Name of file on remote end. If not provided it defaults to the local file name"
+    required: false
   bucket:
     type: "string"
     description: "S3 bucket to upload file"

--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -3,12 +3,3 @@ base_url: ""
 # auth_token will expire per token_ttl specifed in stackstorm
 # configuration and will require a refresh.
 auth_token: ""
-
-### StackStorm S3 Information
-##  These settings are for a write-only S3 account used
-##  when sending information to StackStorm for troubleshooting/analytics
-s3:
-  access_key_id: "AKIAIDM5AFYIL6QTZUIQ"
-  secret_access_key: "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"
-  endpoint: "s3-us-west-2.amazonaws.com"
-  region: "us-west-2"

--- a/packs/st2/requirements.txt
+++ b/packs/st2/requirements.txt
@@ -1,3 +1,2 @@
 st2client>=0.7
 PrettyTable>=0.7.2,<0.8
-s3==3.0.0


### PR DESCRIPTION
This pull request updates `st2.upload_to_s3` action so it supports uploading to any publicly writable S3 bucket. This way we don't need to store any expose S3 credentials in the repo (credentials had limited permissions and only allowed user to write to a specific bucket, but it's still a bad practice).

We use same approach for uploading debugging information to S3. For that to work, we need to configurable bucket's IAM policies so everyone can write to it and only we can read from it (I've already done that).