### PR TITLE
st2.call_home improvements

### DIFF
--- a/packs/st2/actions/workflows/call_home.yaml
+++ b/packs/st2/actions/workflows/call_home.yaml
@@ -73,6 +73,8 @@
         bucket: "{{bucket}}"
         remote_file: "{{server_uuid}}-user-data.json"
     -
+      # no-op task where we go if data collection is disabled. We do that so the workflow still
+      # succeedes if the collection is disabled.
       name: "exit_data_collection_disabled"
       ref: "core.local"
       params:

--- a/packs/st2/actions/workflows/call_home.yaml
+++ b/packs/st2/actions/workflows/call_home.yaml
@@ -9,12 +9,14 @@
       params:
         key: "st2::collect_anonymous_data"
       on-success: "check_for_permission_to_send_anonymous_data"
+      on-failure: "exit_data_collection_disabled"
     -
       name: "check_for_permission_to_send_anonymous_data"
       ref: "st2.check_permissions_anon_data"
       params:
         collect_anonymous_data: "{{ get_collect_anonymous_data_value.result }}"
       on-success: "get_server_uuid"
+      on-failure: "exit_data_collection_disabled"
     -
       name: "get_server_uuid"
       ref: "st2.kv.get"
@@ -70,3 +72,8 @@
         file_name: "{{user_data_file}}"
         bucket: "{{bucket}}"
         remote_file: "{{server_uuid}}-user-data.json"
+    -
+      name: "exit_data_collection_disabled"
+      ref: "core.local"
+      params:
+        cmd: "echo 'Exiting because anonymous data collection is disabled' ; exit 0"


### PR DESCRIPTION
This pull request updates `call_home` workflow so it doesn't fail and exists with a success if `st2::collect_anonymous_data` key is not available or if anonymous data collection is disabled (key value is set to false).

```bash
(virtualenv)vagrant@vagrant-ubuntu-trusty-64:/data/stanley$ python ./st2client/st2client/shell.py run st2.call_home..
id: 5638e8390640fd49ff75c678
action.ref: st2.call_home
status: succeeded
start_timestamp: 2015-11-03T17:00:40.994006Z
end_timestamp: 2015-11-03T17:00:46.351423Z
+--------------------------+-----------+--------------------+--------------------+--------------------+
| id                       | status    | task               | action             | start_timestamp    |
+--------------------------+-----------+--------------------+--------------------+--------------------+
| 5638e8390640fd49fa7a2766 | succeeded | get_collect_anonym | st2.kv.get         | Tue, 03 Nov 2015   |
|                          |           | ous_data_value     |                    | 17:00:41 UTC       |
| 5638e83c0640fd49fa7a2769 | failed    | check_for_permissi | st2.check_permissi | Tue, 03 Nov 2015   |
|                          |           | on_to_send_anonymo | ons_anon_data      | 17:00:44 UTC       |
|                          |           | us_data            |                    |                    |
| 5638e83d0640fd49fa7a276c | succeeded | exit_data_collecti | core.local         | Tue, 03 Nov 2015   |
|                          |           | on_disabled        |                    | 17:00:45 UTC       |
+--------------------------+-----------+--------------------+--------------------+--------------------+

```