### PR TITLE
Work around hubot-help's kinks

### DIFF
--- a/packs/hubot/README.md
+++ b/packs/hubot/README.md
@@ -17,6 +17,6 @@ Pack that provides management/integration with Hubot
 
 ## ChatOps Aliases
 
-* `hubot branch`            -> hubot.branch
-* `hubot deploy {{branch}}` -> hubot.deploy
-* `hubot restart`           -> hubot.restart
+* `bot branch`            -> hubot.branch
+* `bot deploy {{branch}}` -> hubot.deploy
+* `bot restart`           -> hubot.restart

--- a/packs/hubot/aliases/branch.yaml
+++ b/packs/hubot/aliases/branch.yaml
@@ -1,7 +1,7 @@
 ---
 name: "hubot_branch"
 action_ref: "hubot.branch"
-description: "Show the currently deployed hubot branch"
+description: "Show the currently deployed bot branch"
 formats:
-  - "hubot branch"
-  - "hubot branch on {{hosts}}"
+  - "bot branch"
+  - "bot branch on {{hosts}}"

--- a/packs/hubot/aliases/deploy.yaml
+++ b/packs/hubot/aliases/deploy.yaml
@@ -1,7 +1,7 @@
 ---
 name: "hubot_deploy"
 action_ref: "hubot.deploy"
-description: "Deploy a specific git branch of deployed Hubot"
+description: "Deploy a specific git branch of deployed bot"
 formats:
-  - "hubot deploy {{branch}}"
-  - "hubot deploy {{branch}} on {{hosts}}"
+  - "bot deploy {{branch}}"
+  - "bot deploy {{branch}} on {{hosts}}"

--- a/packs/hubot/aliases/restart.yaml
+++ b/packs/hubot/aliases/restart.yaml
@@ -1,7 +1,7 @@
 ---
 name: "hubot_restart"
 action_ref: "hubot.restart"
-description: "Restart Hubot"
+description: "Restart the bot"
 formats:
-  - "hubot restart"
-  - "hubot restart on {{hosts}}"
+  - "bot restart"
+  - "bot restart on {{hosts}}"


### PR DESCRIPTION
`hubot-help` simply replaces any occurrence of 'hubot' with either bot's alias or name. This results in rather strange looking lines like `! ! branch on {{hosts}} - Show the currently deployed ! branch`. By very least, it breaks an immersion and makes our bot looks worse than it is.
