### PR TITLE
re:amaze: Adding ability to post to conversation

### DIFF
--- a/packs/reamaze/actions/create_message.py
+++ b/packs/reamaze/actions/create_message.py
@@ -1,7 +1,6 @@
 # From https://www.reamaze.com/api/post_messages
 
 from lib.actions import BaseAction
-import json
 
 
 class CreateMessage(BaseAction):

--- a/packs/reamaze/actions/create_message.py
+++ b/packs/reamaze/actions/create_message.py
@@ -20,7 +20,7 @@ class CreateMessage(BaseAction):
         }
 
         if suppress_notification:
-            params['suppress_notificiaton'] = True
+            payload['suppress_notificiaton'] = True
 
         endpoint = '/conversations/{}/messages'.format(slug)
         response = self._api_post(endpoint, json=payload)

--- a/packs/reamaze/actions/create_message.py
+++ b/packs/reamaze/actions/create_message.py
@@ -1,0 +1,29 @@
+# From https://www.reamaze.com/api/post_messages
+
+from lib.actions import BaseAction
+import json
+
+
+class CreateMessage(BaseAction):
+    VISIBILITY = {
+        'internal': 1,
+        'regular': 0,
+    }
+
+    def run(self, slug, message, visibility='internal',
+            suppress_notification=False):
+
+        payload = {
+            'message': {
+                'body': message,
+                'visibility': CreateMessage.VISIBILITY[visibility]
+            }
+        }
+
+        if suppress_notification:
+            params['suppress_notificiaton'] = True
+
+        endpoint = '/conversations/{}/messages'.format(slug)
+        response = self._api_post(endpoint, json=payload)
+
+        return response

--- a/packs/reamaze/actions/create_message.yaml
+++ b/packs/reamaze/actions/create_message.yaml
@@ -1,0 +1,26 @@
+---
+name: "create_message"
+runner_type: "python-script"
+description: "Create a new message under a specific conversation"
+enabled: true
+entry_point: "create_message.py"
+parameters:
+  slug:
+    type: "string"
+    description: "Slug name of conversation to be posted to"
+    required: true
+  message:
+    type: "string"
+    description: "Message to be posted to conversation"
+    required: true
+  visibility:
+    type: "string"
+    description: "Regular or internal note type"
+    default: "internal"
+    enum:
+      - "internal"
+      - "regular"
+  suppress_notification:
+    type: boolean
+    description: "Optionally disable an email or integration to be fired with this message"
+    default: false

--- a/packs/reamaze/actions/lib/actions.py
+++ b/packs/reamaze/actions/lib/actions.py
@@ -28,3 +28,13 @@ class BaseAction(Action):
 
         r.raise_for_status()
         return r.json()
+
+    def _api_post(self, endpoint, headers={}, data=None, json=None):
+        _url = self._api_root + endpoint
+        _headers = self._headers.update(headers)
+
+        r = requests.post(url=_url, auth=(self._email, self._token),
+                         data=data, headers=_headers, json=json)
+
+        r.raise_for_status()
+        return r.json()


### PR DESCRIPTION
This PR adds the ability to post to a conversation in re:amaze from StackStorm. Supports all options/parameters except the ability to impersonate another user.