### PR TITLE
Add raw Timestamp to Slack Payload

### DIFF
--- a/packs/slack/README.md
+++ b/packs/slack/README.md
@@ -81,6 +81,7 @@ Example trigger payload:
         "name": "test"
     },
     "timestamp": 1419164091,
+    "timestamp_raw": "1419164091.00005",
     "text": "This is a test message."
 }
 ```

--- a/packs/slack/sensors/slack_sensor.py
+++ b/packs/slack/sensors/slack_sensor.py
@@ -180,6 +180,7 @@ class SlackSensor(PollingSensor):
                 'is_group': channel_info.get('is_group', False),
             },
             'timestamp': int(float(data['ts'])),
+            'timestamp_raw': data['ts'],
             'text': text
         }
 

--- a/packs/slack/sensors/slack_sensor.yaml
+++ b/packs/slack/sensors/slack_sensor.yaml
@@ -18,3 +18,5 @@
             type: "string"
           timestamp:
             type: "integer"
+          timestamp_raw:
+            type: "string"


### PR DESCRIPTION
For the immediate need.

There is some mangling happening, and I need the raw string. (See #336 or #337). So, instead of trying to fix the thing, here is an addition. Less ideal, but unblocks me and I can get going. 

Fixes appreciated. :heart:
