### PR TITLE
Add makefile target which tries to register all the pack resources

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,8 +16,9 @@ env:
     - "TASK=packs-resource-register"
     - "TASK=packs-tests"
 services:
-  # Note: MongoDB is needed for packs-resource-register check
+  # Note: MongoDB and RabbitMQ is needed for packs-resource-register check
   - mongodb
+  - rabbitmq
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,10 @@ services:
   # Note: MongoDB and RabbitMQ is needed for packs-resource-register check
   - mongodb
   - rabbitmq
+addons:
+  apt:
+    packages:
+      - libsox-dev  # needed by witai pack
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,6 +15,9 @@ env:
     - "TASK=metadata-check"
     - "TASK=packs-resource-register"
     - "TASK=packs-tests"
+services:
+  # Note: MongoDB is needed for packs-resource-register check
+  - mongodb
 cache:
   directories:
     - $HOME/.pip-cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ env:
     - "TASK=pylint"
     - "TASK=configs-check"
     - "TASK=metadata-check"
+    - "TASK=packs-register-resources"
     - "TASK=packs-tests"
 cache:
   directories:

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,6 +6,8 @@ os:
 env:
   global:
     - "PIP_DOWNLOAD_CACHE=$HOME/.pip-cache"
+    # Temporary to get PR tests to pass
+    - "ST2_REPO_BRANCH=register_content_fail_on_failure_flag"
   matrix:
     - "TASK=flake8"
     - "TASK=pylint"

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ env:
     - "TASK=pylint"
     - "TASK=configs-check"
     - "TASK=metadata-check"
-    - "TASK=packs-register-resources"
+    - "TASK=packs-resource-register"
     - "TASK=packs-tests"
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 ROOT_DIR := $(shell dirname $(realpath $(lastword $(MAKEFILE_LIST))))
 VIRTUALENV_DIR ?= virtualenv
 ST2_REPO_PATH ?= /tmp/st2
-ST2_REPO_BRANCH ?= master
+ST2_REPO_BRANCH ?= register_content_fail_on_failure_flag
 
 export ST2_REPO_PATH
 
@@ -16,6 +16,9 @@ lint: requirements flake8 pylint configs-check metadata-check
 
 .PHONY: pylint
 pylint: requirements .clone_st2_repo .pylint
+
+.PHONY: resource-register
+resource-register: requirements .clone_st2_repo .resource-register
 
 .PHONY: packs-tests
 packs-tests: requirements .clone_st2_repo .packs-tests
@@ -48,6 +51,13 @@ metadata-check: requirements
 	@echo "==================== metadata-check ===================="
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh
+
+.PHONY: .resource-register
+.resource-register:
+	@echo
+	@echo "==================== resource-register ===================="
+	@echo
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
 
 .PHONY: .packs-tests
 .packs-tests:

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,7 @@ metadata-check: requirements
 	@echo
 	@echo "==================== packs-resource-register ===================="
 	@echo
-	# Note: We skip sensu,nagios packs since rule requires trigger to be registered using the handler script
-	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d \( ! -iname "sensu" ! -name "nagios" \)  -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
 
 .PHONY: .packs-tests
 .packs-tests:

--- a/Makefile
+++ b/Makefile
@@ -57,7 +57,8 @@ metadata-check: requirements
 	@echo
 	@echo "==================== resource-register ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
+	# Note: We skip "sensu" pack since rule requires trigger to be registered using the sensu handler script
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d \( ! -iname "sensu" \)  -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
 
 .PHONY: .packs-tests
 .packs-tests:

--- a/Makefile
+++ b/Makefile
@@ -17,8 +17,8 @@ lint: requirements flake8 pylint configs-check metadata-check
 .PHONY: pylint
 pylint: requirements .clone_st2_repo .pylint
 
-.PHONY: resource-register
-resource-register: requirements .clone_st2_repo .resource-register
+.PHONY: packs-resource-register
+packs-resource-register: requirements .clone_st2_repo .packs-resource-register
 
 .PHONY: packs-tests
 packs-tests: requirements .clone_st2_repo .packs-tests
@@ -52,10 +52,10 @@ metadata-check: requirements
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh
 
-.PHONY: .resource-register
-.resource-register:
+.PHONY: .packs-resource-register
+.packs-resource-register:
 	@echo
-	@echo "==================== resource-register ===================="
+	@echo "==================== packs-resource-register ===================="
 	@echo
 	# Note: We skip sensu,nagios packs since rule requires trigger to be registered using the handler script
 	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d \( ! -iname "sensu" ! -name "nagios" \)  -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME

--- a/Makefile
+++ b/Makefile
@@ -57,8 +57,8 @@ metadata-check: requirements
 	@echo
 	@echo "==================== resource-register ===================="
 	@echo
-	# Note: We skip "sensu" pack since rule requires trigger to be registered using the sensu handler script
-	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d \( ! -iname "sensu" \)  -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
+	# Note: We skip sensu,nagios packs since rule requires trigger to be registered using the handler script
+	. $(VIRTUALENV_DIR)/bin/activate; find ${ROOT_DIR}/packs/* -maxdepth 0 -type d \( ! -iname "sensu" ! -name "nagios" \)  -print0 | xargs -0 -I FILENAME scripts/register-pack-resources.sh FILENAME
 
 .PHONY: .packs-tests
 .packs-tests:

--- a/packs/cubesensors/sensors/measurements_sensor.py
+++ b/packs/cubesensors/sensors/measurements_sensor.py
@@ -66,7 +66,7 @@ class CubeSensorsMeasurementsSensor(PollingSensor):
             device_uid=device_uid)
         new_last_measurement_timestamp = isotime.parse(result['time'])
         new_last_measurement_timestamp = int(time.mktime(
-            new_last_measurement_timestamp.timetuple()))
+            new_last_measurement_timestamp.timetuple()))  # pylint: disable=no-member
 
         if (existing_last_measurement_timestamp and
                 new_last_measurement_timestamp <= existing_last_measurement_timestamp):

--- a/packs/email/sensors/smtp_sensor.py
+++ b/packs/email/sensors/smtp_sensor.py
@@ -37,7 +37,7 @@ class SMTPSensor(Sensor):
 
     def run(self):
         self._logger.debug('[SMTPSensor]: entering run')
-        asyncore.loop()
+        asyncore.loop()  # pylint: disable=no-member
 
     def cleanup(self):
         self._logger.debug('[SMTPSensor]: entering cleanup')

--- a/packs/libcloud/actions/start_vm.py
+++ b/packs/libcloud/actions/start_vm.py
@@ -18,6 +18,6 @@ class StartVMAction(SingleVMAction):
         if status is True:
             self.logger.info('Successfully started node "%s"' % (node))
         else:
-            self.logger.rror('Failed to start node "%s"' % (node))
+            self.logger.error('Failed to start node "%s"' % (node))
 
         return status

--- a/packs/witai/actions/text_query.py
+++ b/packs/witai/actions/text_query.py
@@ -22,6 +22,7 @@ class TextQueryAction(Action):
         if not access_token:
             raise Exception('Missing API key for application %s' % application)
 
+        # pylint: disable=no-member
         wit.init()
         response = wit.text_query(text, access_token)
         wit.close()

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -16,4 +16,12 @@
 
 # File containing common utility functions
 
-function join { local IFS="$1"; shift; echo "$*"; }
+function join()
+{
+    local IFS="$1"; shift; echo "$*";
+}
+
+function get_st2_components() {
+    local ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
+    echo "${ST2_COMPONENTS}"
+}

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -38,7 +38,7 @@ if [[ ${PYTHON_BINARY} != *"virtualenv/bin/python" ]]; then
 fi
 
 ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
-ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 1 -name "st2*" -type d)
+ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
 PACK_PYTHONPATH=$(join ":" ${ST2_COMPONENTS})
 
 echo "Running pylint on pack: ${PACK_NAME}"

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Script which runs pylint on all the Python files in a particular pack.
+#
 
 PACK_PATH=$1
 PACK_NAME=$(basename ${PACK_PATH})

--- a/scripts/pylint-pack.sh
+++ b/scripts/pylint-pack.sh
@@ -38,7 +38,7 @@ if [[ ${PYTHON_BINARY} != *"virtualenv/bin/python" ]]; then
 fi
 
 ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
-ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
+ST2_COMPONENTS=$(get_st2_components)
 PACK_PYTHONPATH=$(join ":" ${ST2_COMPONENTS})
 
 echo "Running pylint on pack: ${PACK_NAME}"

--- a/scripts/register-pack-resources.sh
+++ b/scripts/register-pack-resources.sh
@@ -29,7 +29,7 @@ ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
 PACK_PYTHONPATH=$(join ":" ${ST2_COMPONENTS})
 
 REGISTER_SCRIPT_PATH="${ST2_REPO_PATH}/st2common/bin/st2-register-content"
-REGISTER_SCRIPT_FLAGS="-v --register-fail-on-failure --config-file=${ST2_REPO_PATH}/conf/st2.tests.conf --register-all"
+REGISTER_SCRIPT_FLAGS="-v --register-fail-on-failure --config-file=scripts/st2.tests.conf --register-all"
 
 # Install st2 dependencies
 pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt

--- a/scripts/register-pack-resources.sh
+++ b/scripts/register-pack-resources.sh
@@ -39,4 +39,10 @@ export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 
 echo "Registering all content from pack ${PACK_NAME}"
 ${REGISTER_SCRIPT_PATH} ${REGISTER_SCRIPT_FLAGS} --register-pack=${PACK_PATH}
-exit $?
+EXIT_CODE=$?
+
+if [ ${EXIT_CODE} -ne 0 ]; then
+    echo "Registering resources for pack ${PACK_NAME} failed"
+fi
+
+exit ${EXIT_CODE}

--- a/scripts/register-pack-resources.sh
+++ b/scripts/register-pack-resources.sh
@@ -22,10 +22,20 @@
 PACK_PATH=$1
 PACK_NAME=$(basename ${PACK_PATH})
 
+source ./scripts/common.sh
+
 ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
+ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
+PACK_PYTHONPATH=$(join ":" ${ST2_COMPONENTS})
 
 REGISTER_SCRIPT_PATH="${ST2_REPO_PATH}/st2common/bin/st2-register-content"
 REGISTER_SCRIPT_FLAGS="-v --register-fail-on-failure --config-file=${ST2_REPO_PATH}/conf/st2.tests.conf --register-all"
+
+# Install st2 dependencies
+pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
+
+# Set PYTHONPATH to include st2 components
+export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 
 echo "Registering all content from pack ${PACK_NAME}"
 ${REGISTER_SCRIPT_PATH} ${REGISTER_SCRIPT_FLAGS} --register-pack=${PACK_PATH}

--- a/scripts/register-pack-resources.sh
+++ b/scripts/register-pack-resources.sh
@@ -29,7 +29,15 @@ ST2_COMPONENTS=$(get_st2_components)
 PACK_PYTHONPATH=$(join ":" ${ST2_COMPONENTS})
 
 REGISTER_SCRIPT_PATH="${ST2_REPO_PATH}/st2common/bin/st2-register-content"
-REGISTER_SCRIPT_FLAGS="-v --register-fail-on-failure --config-file=scripts/st2.tests.conf --register-all"
+REGISTER_SCRIPT_COMMON_FLAGS="-v --register-fail-on-failure --config-file=scripts/st2.tests.conf"
+
+# Note: Rules in some packs rely on triggers which are created lazily later on
+# so we can't test rule registration for those packs.
+if [ ${PACK_NAME} = "sensu" ] || [ ${PACK_NAME} = "nagios" ]  || [ ${PACK_NAME} = "hubot" ]; then
+    REGISTER_SCRIPT_REGISTER_FLAGS="--register-sensors --register-actions --register-aliases --register-policies"
+else
+    REGISTER_SCRIPT_REGISTER_FLAGS="--register-all"
+fi
 
 # Install st2 dependencies
 pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.txt
@@ -37,8 +45,8 @@ pip install --cache-dir ${HOME}/.pip-cache -q -r ${ST2_REPO_PATH}/requirements.t
 # Set PYTHONPATH to include st2 components
 export PYTHONPATH=${PACK_PYTHONPATH}:${PYTHONPATH}
 
-echo "Registering all content from pack ${PACK_NAME}"
-${REGISTER_SCRIPT_PATH} ${REGISTER_SCRIPT_FLAGS} --register-pack=${PACK_PATH}
+echo "Registering content from pack ${PACK_NAME}"
+${REGISTER_SCRIPT_PATH} ${REGISTER_SCRIPT_COMMON_FLAGS} ${REGISTER_SCRIPT_REGISTER_FLAGS} --register-pack=${PACK_PATH}
 EXIT_CODE=$?
 
 if [ ${EXIT_CODE} -ne 0 ]; then

--- a/scripts/register-pack-resources.sh
+++ b/scripts/register-pack-resources.sh
@@ -25,7 +25,7 @@ PACK_NAME=$(basename ${PACK_PATH})
 source ./scripts/common.sh
 
 ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
-ST2_COMPONENTS=$(find ${ST2_REPO_PATH}/* -maxdepth 0 -name "st2*" -type d)
+ST2_COMPONENTS=$(get_st2_components)
 PACK_PYTHONPATH=$(join ":" ${ST2_COMPONENTS})
 
 REGISTER_SCRIPT_PATH="${ST2_REPO_PATH}/st2common/bin/st2-register-content"

--- a/scripts/register-pack-resources.sh
+++ b/scripts/register-pack-resources.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Script which tries to register all the resources from a particular pack and
+# fails (exits with non-zero) if registering a particular resource fails.
+#
+
+PACK_PATH=$1
+PACK_NAME=$(basename ${PACK_PATH})
+
+ST2_REPO_PATH=${ST2_REPO_PATH:-/tmp/st2}
+
+REGISTER_SCRIPT_PATH="${ST2_REPO_PATH}/st2common/bin/st2-register-content"
+REGISTER_SCRIPT_FLAGS="-v --register-fail-on-failure --config-file=${ST2_REPO_PATH}/conf/st2.tests.conf --register-all"
+
+echo "Registering all content from pack ${PACK_NAME}"
+${REGISTER_SCRIPT_PATH} ${REGISTER_SCRIPT_FLAGS} --register-pack=${PACK_PATH}
+exit $?

--- a/scripts/st2.tests.conf
+++ b/scripts/st2.tests.conf
@@ -1,0 +1,75 @@
+# Config file used by integration tests
+#
+[api]
+# Host and port to bind the API server.
+host = 0.0.0.0
+port = 9101
+logging = st2tests/conf/logging.api.conf
+mask_secrets = False
+# allow_origin is required for handling CORS in st2 web UI.
+# allow_origin = http://myhost1.example.com:3000,http://myhost2.example.com:3000
+
+[sensorcontainer]
+logging = st2tests/conf/logging.sensorcontainer.conf
+sensor_node_name = sensornode1
+partition_provider = name:default
+
+[rulesengine]
+logging = st2reactor/conf/logging.rulesengine.conf
+
+[actionrunner]
+logging = st2actions/conf/logging.conf
+
+[auth]
+host = 0.0.0.0
+port = 9100
+use_ssl = False
+debug = False
+enable = False
+logging = st2tests/conf/logging.auth.conf
+
+mode = standalone
+backend = flat_file
+backend_kwargs = {"file_path": "st2auth/conf/htpasswd_dev"}
+
+# Base URL to the API endpoint excluding the version (e.g. http://myhost.net:9101/)
+api_url = http://127.0.0.1:9101/
+
+[system]
+base_path = /opt/stackstorm
+admin_users = testu
+
+[content]
+system_packs_base_path =
+packs_base_paths = packs/
+
+[syslog]
+host = localhost
+port = 514
+facility = local7
+protocol = udp
+
+[log]
+excludes = requests,paramiko
+redirect_stderr = False
+mask_secrets = False
+
+[system_user]
+user = stanley
+ssh_key_file = /home/vagrant/.ssh/stanley_rsa
+
+[messaging]
+url = amqp://guest:guest@localhost:5672/
+
+[ssh_runner]
+remote_dir = /tmp
+use_paramiko_ssh_runner = True
+
+[resultstracker]
+logging = st2actions/conf/logging.resultstracker.conf
+
+[notifier]
+logging = st2actions/conf/logging.notifier.conf
+
+[exporter]
+logging = st2exporter/conf/logging.exporter.conf

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -14,8 +14,8 @@ elif [ ${TASK} == "configs-check" ]; then
   make configs-check
 elif [ ${TASK} == "metadata-check" ]; then
   make metadata-check
-elif [ ${TASK} == "pack-register-resources" ]; then
-  make packs-register-resources
+elif [ ${TASK} == "pack-resource-register" ]; then
+  make packs-resource-register
 elif [ ${TASK} == "packs-tests" ]; then
   make packs-tests
 else

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -14,7 +14,7 @@ elif [ ${TASK} == "configs-check" ]; then
   make configs-check
 elif [ ${TASK} == "metadata-check" ]; then
   make metadata-check
-elif [ ${TASK} == "pack-resource-register" ]; then
+elif [ ${TASK} == "packs-resource-register" ]; then
   make packs-resource-register
 elif [ ${TASK} == "packs-tests" ]; then
   make packs-tests

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -14,6 +14,8 @@ elif [ ${TASK} == "configs-check" ]; then
   make configs-check
 elif [ ${TASK} == "metadata-check" ]; then
   make metadata-check
+elif [ ${TASK} == "pack-register-resources" ]; then
+  make packs-register-resources
 elif [ ${TASK} == "packs-tests" ]; then
   make packs-tests
 else

--- a/scripts/validate-json-file.sh
+++ b/scripts/validate-json-file.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Script which validates the syntax in a JSON file.
+#
 
 FILE=$1
 

--- a/scripts/validate-pack-metadata-exists.sh
+++ b/scripts/validate-pack-metadata-exists.sh
@@ -1,4 +1,22 @@
 #!/usr/bin/env bash
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+#
+# Script which validates that a pack contains metaata file (pack.yaml).
+#
 
 FILE=$1
 

--- a/scripts/validate-yaml-file.sh
+++ b/scripts/validate-yaml-file.sh
@@ -1,5 +1,22 @@
 #!/usr/bin/env bash
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
+#
+# Script which validates the syntax in a YAML file.
+#
 FILE=$1
 
 echo "Validating YAML syntax for file ${FILE}..."


### PR DESCRIPTION
This pull request adds a new make target and script which tries to register all the pack resources and exits with non-zero if registration fails.

This will allow us to detect all kind of resource metadata related issues early on (invalid syntax in the metadata file, invalid parameter name, etc.).

Depends on https://github.com/StackStorm/st2/pull/2291