### PR TITLE
Speed up makefile checks

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ services:
 addons:
   apt:
     packages:
+      - git  # needed by git-changes scripts
       - libsox-dev  # needed by witai pack
 cache:
   directories:

--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ export ST2_REPO_PATH ROOT_DIR
 COMPONENTS := $(wildcard /tmp/st2/st2*)
 
 .PHONY: all
-all: requirements lint
+all: requirements lint packs-resource-register packs-tests
 
 .PHONY: lint
 lint: requirements flake8 pylint configs-check metadata-check

--- a/Makefile
+++ b/Makefile
@@ -35,43 +35,43 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo
 	@echo "==================== pylint ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/pylint-pack.sh $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PACKS}" ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/pylint-pack.sh $$pack; fi; done
 
 .PHONY: flake8
 flake8: requirements
 	@echo
 	@echo "==================== flake8 ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PY} ]; then echo No files have changed, skipping run...; fi; for file in ${CHANGED_PY}; do if [ -n "$$file" ]; then flake8 --config ./.flake8 $$file; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PY}" ]; then echo No files have changed, skipping run...; fi; for file in ${CHANGED_PY}; do if [ -n "$$file" ]; then flake8 --config ./.flake8 $$file; fi; done
 
 .PHONY: configs-check
 configs-check: requirements
 	@echo
 	@echo "==================== configs-check ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_YAML} ]; then echo No files have changed, skipping run...; fi; for file in $(CHANGED_YAML); do if [ -n "$$file" ]; then ./scripts/validate-yaml-file.sh $$file; fi; done
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_JSON} ]; then echo No files have changed, skipping run...; fi; for file in $(CHANGED_JSON); do if [ -n "$$file" ]; then ./scripts/validate-json-file.sh $$file; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_YAML}" ]; then echo No files have changed, skipping run...; fi; for file in $(CHANGED_YAML); do if [ -n "$$file" ]; then ./scripts/validate-yaml-file.sh $$file; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_JSON}" ]; then echo No files have changed, skipping run...; fi; for file in $(CHANGED_JSON); do if [ -n "$$file" ]; then ./scripts/validate-json-file.sh $$file; fi; done
 
 .PHONY: metadata-check
 metadata-check: requirements
 	@echo
 	@echo "==================== metadata-check ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PACKS}" ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh $$pack; fi; done
 
 .PHONY: .packs-resource-register
 .packs-resource-register:
 	@echo
 	@echo "==================== packs-resource-register ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/register-pack-resources.sh $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PACKS}" ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/register-pack-resources.sh $$pack; fi; done
 
 .PHONY: .packs-tests
 .packs-tests:
 	@echo
 	@echo "==================== packs-tests ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then $(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -x -p $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PACKS}" ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then $(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -x -p $$pack; fi; done
 
 .PHONY: .clone_st2_repo
 .clone_st2_repo:

--- a/Makefile
+++ b/Makefile
@@ -56,7 +56,7 @@ metadata-check: requirements
 	@echo
 	@echo "==================== metadata-check ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh
+	. $(VIRTUALENV_DIR)/bin/activate; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh $$pack; fi; done
 
 .PHONY: .packs-resource-register
 .packs-resource-register:

--- a/Makefile
+++ b/Makefile
@@ -8,8 +8,9 @@ CHANGED_JSON := $(shell $(ROOT_DIR)/scripts/utils/git-changes json)
 VIRTUALENV_DIR ?= virtualenv
 ST2_REPO_PATH ?= /tmp/st2
 ST2_REPO_BRANCH ?= register_content_fail_on_failure_flag
+FORCE_CHECK_ALL_FILES =? false
 
-export ST2_REPO_PATH ROOT_DIR
+export ST2_REPO_PATH ROOT_DIR FORCE_CHECK_ALL_FILES
 
 # All components are prefixed by st2
 COMPONENTS := $(wildcard /tmp/st2/st2*)

--- a/Makefile
+++ b/Makefile
@@ -35,43 +35,43 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo
 	@echo "==================== pylint ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/pylint-pack.sh $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/pylint-pack.sh $$pack; fi; done
 
 .PHONY: flake8
 flake8: requirements
 	@echo
 	@echo "==================== flake8 ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; for file in ${CHANGED_PY}; do if [ -n "$$file" ]; then flake8 --config ./.flake8 $$file; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PY} ]; then echo No files have changed, skipping run...; fi; for file in ${CHANGED_PY}; do if [ -n "$$file" ]; then flake8 --config ./.flake8 $$file; fi; done
 
 .PHONY: configs-check
 configs-check: requirements
 	@echo
 	@echo "==================== configs-check ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; for file in $(CHANGED_YAML); do if [ -n "$$file" ]; then ./scripts/validate-yaml-file.sh $$file; fi; done
-	. $(VIRTUALENV_DIR)/bin/activate; for file in $(CHANGED_JSON); do if [ -n "$$file" ]; then ./scripts/validate-json-file.sh $$file; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_YAML} ]; then echo No files have changed, skipping run...; fi; for file in $(CHANGED_YAML); do if [ -n "$$file" ]; then ./scripts/validate-yaml-file.sh $$file; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_JSON} ]; then echo No files have changed, skipping run...; fi; for file in $(CHANGED_JSON); do if [ -n "$$file" ]; then ./scripts/validate-json-file.sh $$file; fi; done
 
 .PHONY: metadata-check
 metadata-check: requirements
 	@echo
 	@echo "==================== metadata-check ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then ${ROOT_DIR}/scripts/validate-pack-metadata-exists.sh $$pack; fi; done
 
 .PHONY: .packs-resource-register
 .packs-resource-register:
 	@echo
 	@echo "==================== packs-resource-register ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/register-pack-resources.sh $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/register-pack-resources.sh $$pack; fi; done
 
 .PHONY: .packs-tests
 .packs-tests:
 	@echo
 	@echo "==================== packs-tests ===================="
 	@echo
-	. $(VIRTUALENV_DIR)/bin/activate; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then $(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -x -p $$pack; fi; done
+	. $(VIRTUALENV_DIR)/bin/activate; if [ ! ${CHANGED_PACKS} ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then $(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -x -p $$pack; fi; done
 
 .PHONY: .clone_st2_repo
 .clone_st2_repo:

--- a/README.md
+++ b/README.md
@@ -23,11 +23,30 @@ Related tools that help make it easier to integrate and consume StackStorm conte
 
 ## Tests and Automated Checks
 
-To run tests and all the other automated checks which run on Travis CI, run the following
-command:
+By default, Travis CI runs the following checks (makefiles tasks):
+
+* ``flake8`` - Runs ``flake8`` on all the Python files.
+* ``pylint`` - Runs ``pylint`` on all the Python files.
+* ``configs-check`` - Makes sure that all the JSON and YAML resource metadata
+  files contain correct syntax.
+* ``metadata-check`` - Verifies that each pack contains pack metadata file
+  (``pack.yaml``).
+* ``packs-resource-register`` - Registers resources from all the packs and
+  makes sure the registration succeeds.
+* ``packs-tests`` - Runs tests for all the packs.
+
+To run all those checks locally, you can use the following command:
 
 ```bash
 make all
+```
+
+By default, this command will only perform checks on changed files and packs. If you want
+to run checks on all the files and packs (regardless if they changed or not), you can do
+that by specifying ``FORCE_CHECK_ALL_FILES=true`` environment variable as show below.
+
+```bash
+FORCE_CHECK_ALL_FILES=true make all
 ```
 
 ## Available Packs

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -1,8 +1,16 @@
 #!/usr/bin/env bash
 
+GIT_BRANCH=$(git rev-parse --abbrev-ref HEAD)
+
 if [ -z ${TASK} ]; then
   echo "No task provided"
   exit 2
+fi
+
+# When running on master branch we want to run checks on all the files / packs
+# not only on changes ones.
+if [ "${GIT_BRANCH}" = "master" ]; then
+    export FORCE_CHECK_ALL_FILES=true
 fi
 
 if [ ${TASK} == "flake8" ]; then

--- a/scripts/travis.sh
+++ b/scripts/travis.sh
@@ -3,8 +3,7 @@
 if [ -z ${TASK} ]; then
   echo "No task provided"
   exit 2
-  fi
-
+fi
 
 if [ ${TASK} == "flake8" ]; then
   make flake8

--- a/scripts/utils/git-changes
+++ b/scripts/utils/git-changes
@@ -1,0 +1,12 @@
+#!/usr/bin/env sh
+ROOT_DIR=$(git rev-parse --show-toplevel)
+METHOD=$1
+
+case $METHOD in
+  files|directories|packs|py|yaml|json)
+    $ROOT_DIR/scripts/utils/git-changes-$METHOD $ROOT_DIR
+    ;;
+  *)
+    echo "Unknown type. Use files, directories, or packs"
+    ;;
+esac

--- a/scripts/utils/git-changes-directories
+++ b/scripts/utils/git-changes-directories
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+GIT_DIRECTORY=$1
+
+cd $GIT_DIRECTORY
+echo $(git diff --name-only master | xargs -I FILENAME dirname FILENAME | awk '/^\./ {next} /.*/{print "./"$1}')

--- a/scripts/utils/git-changes-files
+++ b/scripts/utils/git-changes-files
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+GIT_DIRECTORY=$1
+
+cd $GIT_DIRECTORY
+echo $(git diff --name-only master)

--- a/scripts/utils/git-changes-json
+++ b/scripts/utils/git-changes-json
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+GIT_DIRECTORY=$1
+
+cd $GIT_DIRECTORY
+echo $(git diff --name-only master -- '*.json')

--- a/scripts/utils/git-changes-json
+++ b/scripts/utils/git-changes-json
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
+ROOT_DIR=$(git rev-parse --show-toplevel)
 GIT_DIRECTORY=$1
+
+# If this environment variable if specified we will return all the files so the
+# checks run on all the files not only changed ones.
+if [ "${FORCE_CHECK_ALL_FILES}" = "true" ]; then
+    echo $(find ${ROOT_DIR}/packs/* -name "*.json")
+    exit 0
+fi
 
 cd $GIT_DIRECTORY
 echo $(git diff --name-only master -- '*.json')

--- a/scripts/utils/git-changes-packs
+++ b/scripts/utils/git-changes-packs
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+GIT_DIRECTORY=$1
+
+cd $GIT_DIRECTORY
+echo $(git diff --name-only master -- 'packs/*' | xargs -I FILENAME dirname FILENAME | awk -F'/' '/^\./ {next} /^[^\/]+$/ {next} /^scripts/ {next} /.*/{print $1"/"$2"/"}' | uniq) 

--- a/scripts/utils/git-changes-packs
+++ b/scripts/utils/git-changes-packs
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
+ROOT_DIR=$(git rev-parse --show-toplevel)
 GIT_DIRECTORY=$1
+
+# If this environment variable if specified we will return all the files so the
+# checks run on all the files not only changed ones.
+if [ "${FORCE_CHECK_ALL_FILES}" = "true" ]; then
+    echo $(find ${ROOT_DIR}/packs/* -maxdepth 0 -type d)
+    exit 0
+fi
 
 cd $GIT_DIRECTORY
 echo $(git diff --name-only master -- 'packs/*' | xargs -I FILENAME dirname FILENAME | awk -F'/' '/^\./ {next} /^[^\/]+$/ {next} /^scripts/ {next} /.*/{print $1"/"$2"/"}' | uniq) 

--- a/scripts/utils/git-changes-py
+++ b/scripts/utils/git-changes-py
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
+ROOT_DIR=$(git rev-parse --show-toplevel)
 GIT_DIRECTORY=$1
+
+# If this environment variable if specified we will return all the files so the
+# checks run on all the files not only changed ones.
+if [ "${FORCE_CHECK_ALL_FILES}" = "true" ]; then
+    echo $(find ${ROOT_DIR}/packs/* -name "*.py")
+    exit 0
+fi
 
 cd $GIT_DIRECTORY
 echo $(git diff --name-only master -- '*.py')

--- a/scripts/utils/git-changes-py
+++ b/scripts/utils/git-changes-py
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+GIT_DIRECTORY=$1
+
+cd $GIT_DIRECTORY
+echo $(git diff --name-only master -- '*.py')

--- a/scripts/utils/git-changes-yaml
+++ b/scripts/utils/git-changes-yaml
@@ -1,5 +1,13 @@
 #!/usr/bin/env sh
+ROOT_DIR=$(git rev-parse --show-toplevel)
 GIT_DIRECTORY=$1
+
+# If this environment variable if specified we will return all the files so the
+# checks run on all the files not only changed ones.
+if [ "${FORCE_CHECK_ALL_FILES}" = "true" ]; then
+    echo $(find ${ROOT_DIR}/packs/* -name "*.yaml")
+    exit 0
+fi
 
 cd $GIT_DIRECTORY
 echo $(git diff --name-only master -- '*.yaml' '*.yml')

--- a/scripts/utils/git-changes-yaml
+++ b/scripts/utils/git-changes-yaml
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+GIT_DIRECTORY=$1
+
+cd $GIT_DIRECTORY
+echo $(git diff --name-only master -- '*.yaml' '*.yml')

--- a/scripts/validate-pack-metadata-exists.sh
+++ b/scripts/validate-pack-metadata-exists.sh
@@ -18,19 +18,14 @@
 # Script which validates that a pack contains metaata file (pack.yaml).
 #
 
-FILE=$1
+PACK_DIR=$1
+PACK_NAME=$(basename $PACK_DIR)
 
-for pack in packs/*; do
-    pack=$(basename "${pack}")
+if [ ${PACK_NAME} == "linux" ]; then
+    exit 0
+fi
 
-    if [ ${pack} == "linux" ]; then
-        continue
-    fi
-
-    if [ ! -e "packs/${pack}/pack.yaml" ]; then
-        echo "Pack "${pack}" is missing pack.yaml file"
-        exit 1;
-    fi
-done
-
-exit 0
+if [ ! -e "${PACK_DIR}/pack.yaml" ]; then
+    echo "Pack "${pack}" is missing pack.yaml file"
+    exit 1
+fi

--- a/scripts/validate-pack-metadata-exists.sh
+++ b/scripts/validate-pack-metadata-exists.sh
@@ -21,7 +21,7 @@
 PACK_DIR=$1
 PACK_NAME=$(basename $PACK_DIR)
 
-if [ ${PACK_NAME} == "linux" ]; then
+if [ ${PACK_NAME} = "linux" ]; then
     exit 0
 fi
 


### PR DESCRIPTION
This pull request cherry picks changes from #332.

On top of that it includes some fixes and improvements for those changes. Most notably, we now only operate on changed files inside PRs / branchs. When the checks run under master branch we will still run them on all the files. That's a final safe guard in case something goes wrong.

As noted here (https://github.com/StackStorm/st2contrib/pull/332#issuecomment-163088243), using naive file / pack changes approach is not totally safe since other things which can affect on the test / check result can also change (e.g. third party dependency, st2 repo, etc.) and we won't detect those changes.

Hopefully though still running checks on all the files on the master branch should be sufficient to catch those issues while still preserving the original benefit of those changes - providing a better (and faster) experience for the user who is submitting a PR.