### PR TITLE
Feature/create node kwargs

### DIFF
--- a/packs/libcloud/actions/create_vm.py
+++ b/packs/libcloud/actions/create_vm.py
@@ -1,5 +1,4 @@
 from libcloud.compute.base import NodeSize
-from libcloud.compute.base import NodeImage
 from libcloud.compute.base import NodeLocation
 
 from lib.actions import BaseAction

--- a/packs/libcloud/actions/create_vm.py
+++ b/packs/libcloud/actions/create_vm.py
@@ -46,4 +46,4 @@ class CreateVMAction(BaseAction):
         node = driver.create_node(**kwargs)
 
         self.logger.info('Node successfully created: %s' % (node))
-        return node
+        return self.resultsets.formatter(node)

--- a/packs/libcloud/actions/create_vm.py
+++ b/packs/libcloud/actions/create_vm.py
@@ -32,11 +32,10 @@ class CreateVMAction(BaseAction):
             size = [s for s in driver.list_sizes() if size_name in s.name][0]
 
         if image_id is not None:
-            image = NodeImage(id=image_id, name=None,
-                              driver=driver)
+            image = [i for i in driver.list_images() if image_id == i.id][0]
         elif image_name is not None:
             image = [i for i in driver.list_images() if
-                     image_name in i['extra'].get('displaytext', image.name)][0]
+                     image_name in i.extra.get('displaytext', i.name)][0]
 
         kwargs = {'name': name, 'size': size, 'image': image}
 

--- a/packs/libcloud/actions/create_vm.py
+++ b/packs/libcloud/actions/create_vm.py
@@ -42,11 +42,10 @@ class CreateVMAction(BaseAction):
             kwargs['location'] = location
 
         if 'create_node_kwargs' in self.config['credentials'][credentials]:
+            self.logger.info('adding extra kwargs to the deployment %s' % self.config['credentials'][credentials]['create_node_kwargs'])
             assert isinstance(self.config['credentials'][credentials]['create_node_kwargs'], dict)
             kwargs.update(self.config['credentials'][credentials]['create_node_kwargs'])
-
         self.logger.info('Creating node...')
-
         node = driver.create_node(**kwargs)
 
         self.logger.info('Node successfully created: %s' % (node))

--- a/packs/libcloud/actions/create_vm.py
+++ b/packs/libcloud/actions/create_vm.py
@@ -41,6 +41,10 @@ class CreateVMAction(BaseAction):
         if location_id:
             kwargs['location'] = location
 
+        if 'create_node_kwargs' in self.config['credentials'][credentials]:
+            assert isinstance(self.config['credentials'][credentials]['create_node_kwargs'], dict)
+            kwargs.update(self.config['credentials'][credentials]['create_node_kwargs'])
+
         self.logger.info('Creating node...')
 
         node = driver.create_node(**kwargs)


### PR DESCRIPTION
When users are running create_vm it's useful to define defaults for some drivers. this would be in create_node_kwargs within the config.yaml for each driver setting.

