### PR TITLE
Add mailbox metadata to IMAP sensor

### DIFF
--- a/packs/email/README.md
+++ b/packs/email/README.md
@@ -180,6 +180,13 @@ Example trigger payload:
             "datastore_key": "attachments-0d61eabdb749789c96853dcbbd933884",
             "content_type": "text/plain"
         }
-    ]
+    ],
+    "mailbox_metadata": {
+        "server": "email.stackstorm.com",
+        "port": 993,
+        "username": "kami@stackstorm.com",
+        "folder": "Process",
+        "ssl": true
+    }
 }
 ```

--- a/packs/email/README.md
+++ b/packs/email/README.md
@@ -184,7 +184,7 @@ Example trigger payload:
     "mailbox_metadata": {
         "server": "email.stackstorm.com",
         "port": 993,
-        "username": "kami@stackstorm.com",
+        "user": "kami@stackstorm.com",
         "folder": "Process",
         "ssl": true
     }

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -115,7 +115,8 @@ class IMAPSensor(PollingSensor):
             }
             self._mailboxes[mailbox] = item
 
-    def _poll_for_unread_messages(self, name, mailbox, mailbox_metadata, download_attachments=False):
+    def _poll_for_unread_messages(self, name, mailbox, mailbox_metadata,
+                                  download_attachments=False):
         self._logger.debug('[IMAPSensor]: polling mailbox {0}'.format(name))
 
         messages = mailbox.unseen()
@@ -126,7 +127,8 @@ class IMAPSensor(PollingSensor):
                                   download_attachments=download_attachments,
                                   mailbox_metadata=mailbox_metadata)
 
-    def _process_message(self, uid, mailbox, mailbox_metadata, download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
+    def _process_message(self, uid, mailbox, mailbox_metadata,
+                         download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
         message = mailbox.mail(uid, include_raw=True)
         mime_msg = mime.from_string(message.raw)
 

--- a/packs/email/sensors/imap_sensor.py
+++ b/packs/email/sensors/imap_sensor.py
@@ -51,8 +51,11 @@ class IMAPSensor(PollingSensor):
         for name, values in self._mailboxes.items():
             mailbox = values['connection']
             download_attachments = values['download_attachments']
+            mailbox_metadata = values['mailbox_metadata']
+
             self._poll_for_unread_messages(name=name, mailbox=mailbox,
-                                           download_attachments=download_attachments)
+                                           download_attachments=download_attachments,
+                                           mailbox_metadata=mailbox_metadata)
             mailbox.quit()
 
     def cleanup(self):
@@ -101,11 +104,18 @@ class IMAPSensor(PollingSensor):
 
             item = {
                 'connection': connection,
-                'download_attachments': download_attachments
+                'download_attachments': download_attachments,
+                'mailbox_metadata': {
+                    'server': server,
+                    'port': port,
+                    'user': user,
+                    'folder': folder,
+                    'ssl': ssl
+                }
             }
             self._mailboxes[mailbox] = item
 
-    def _poll_for_unread_messages(self, name, mailbox, download_attachments=False):
+    def _poll_for_unread_messages(self, name, mailbox, mailbox_metadata, download_attachments=False):
         self._logger.debug('[IMAPSensor]: polling mailbox {0}'.format(name))
 
         messages = mailbox.unseen()
@@ -113,9 +123,10 @@ class IMAPSensor(PollingSensor):
         self._logger.debug('[IMAPSensor]: Processing {0} new messages'.format(len(messages)))
         for message in messages:
             self._process_message(uid=message.uid, mailbox=mailbox,
-                                  download_attachments=download_attachments)
+                                  download_attachments=download_attachments,
+                                  mailbox_metadata=mailbox_metadata)
 
-    def _process_message(self, uid, mailbox, download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
+    def _process_message(self, uid, mailbox, mailbox_metadata, download_attachments=DEFAULT_DOWNLOAD_ATTACHMENTS):
         message = mailbox.mail(uid, include_raw=True)
         mime_msg = mime.from_string(message.raw)
 
@@ -141,7 +152,8 @@ class IMAPSensor(PollingSensor):
             'message_id': message_id,
             'body': body,
             'has_attachments': has_attachments,
-            'attachments': []
+            'attachments': [],
+            'mailbox_metadata': mailbox_metadata
         }
 
         if has_attachments and download_attachments:

--- a/packs/email/sensors/imap_sensor.yaml
+++ b/packs/email/sensors/imap_sensor.yaml
@@ -16,3 +16,4 @@ trigger_types:
       - message_id
       - body
       - attachments
+      - mailbox_metadata


### PR DESCRIPTION
This PR adds additional trigger metadata to pass information about the source mailbox, such as server, port, and folder.