### PR TITLE
process channel_joined message subtype

### DIFF
--- a/packs/slack/sensors/slack_sensor.yaml
+++ b/packs/slack/sensors/slack_sensor.yaml
@@ -20,3 +20,17 @@
             type: "integer"
           timestamp_raw:
             type: "string"
+    -
+      name: "message_channel_join"
+      description: "Trigger indicating a user has joined the channel"
+      payload_schema:
+        type: "object"
+        properties:
+          user:
+            type: "object"
+          text:
+            type: "string"
+          timestamp:
+            type: "integer"
+          timestamp_raw:
+            type "string"


### PR DESCRIPTION
This PR updates the `_process_message` function to have some logic to process a message subtype (https://api.slack.com/events/message) so they are not discarded by the mainline logic.