### PR TITLE
Update SmartThings Payload to use API Key

### DIFF
--- a/packs/smartthings/etc/smartthings-adapter.groovy
+++ b/packs/smartthings/etc/smartthings-adapter.groovy
@@ -140,7 +140,7 @@ def sendEventToStackStorm(event) {
 
   def uri = st2Server
   def headers = [
-    "X-API-Key": st2ApiKey,
+    "St2-Api-Key": st2ApiKey,
     "Content-Type": "application/json",
   ]
 


### PR DESCRIPTION
Updates to appropriate HTTP header for API authentication per https://docs.stackstorm.com/authentication.html?highlight=apikey#api-key-usage