### PR TITLE
added project parameter to create_issue action

### DIFF
--- a/packs/jira/actions/create_issue.py
+++ b/packs/jira/actions/create_issue.py
@@ -7,8 +7,11 @@ __all__ = [
 
 
 class CreateJiraIssueAction(BaseJiraAction):
-    def run(self, summary, type, description=None):
-        project = self.config['project']
+    def run(self, summary, type, description=None, project=None):
+        if project:
+            project = project
+        else:
+            project = self.config['project']
 
         data = {
             'project': {'key': project},

--- a/packs/jira/actions/create_issue.py
+++ b/packs/jira/actions/create_issue.py
@@ -8,11 +8,7 @@ __all__ = [
 
 class CreateJiraIssueAction(BaseJiraAction):
     def run(self, summary, type, description=None, project=None):
-        if project:
-            project = project
-        else:
-            project = self.config['project']
-
+        project = project or self.config['project']
         data = {
             'project': {'key': project},
             'summary': summary,

--- a/packs/jira/actions/create_issue.yaml
+++ b/packs/jira/actions/create_issue.yaml
@@ -23,3 +23,7 @@ parameters:
     type: string
     description: Issue description.
     required: false
+  project:
+    type: string
+    description: destination Project in Jira.
+    required: false


### PR DESCRIPTION
This allows one to override the default project from config file, now, anyone can use something like this:

`st2 action execute jira.create_issue description="testing st2" summary="stackstorm test ticket" project="TESTPROJECT"`