### PR TITLE
added extra_fields option

### DIFF
--- a/packs/jira/actions/create_issue.py
+++ b/packs/jira/actions/create_issue.py
@@ -7,7 +7,9 @@ __all__ = [
 
 
 class CreateJiraIssueAction(BaseJiraAction):
-    def run(self, summary, type, description=None, project=None):
+
+    def run(self, summary, type, description=None,
+            project=None, extra_fields=None):
         project = project or self.config['project']
         data = {
             'project': {'key': project},
@@ -17,6 +19,10 @@ class CreateJiraIssueAction(BaseJiraAction):
 
         if description:
             data['description'] = description
+
+        if extra_fields:
+            for field in extra_fields.keys():
+                data[field] = extra_fields[field]
 
         issue = self._client.create_issue(fields=data)
         result = to_issue_dict(issue)

--- a/packs/jira/actions/create_issue.py
+++ b/packs/jira/actions/create_issue.py
@@ -21,8 +21,7 @@ class CreateJiraIssueAction(BaseJiraAction):
             data['description'] = description
 
         if extra_fields:
-            for field in extra_fields.keys():
-                data[field] = extra_fields[field]
+            data.update(extra_fields)
 
         issue = self._client.create_issue(fields=data)
         result = to_issue_dict(issue)

--- a/packs/jira/actions/create_issue.yaml
+++ b/packs/jira/actions/create_issue.yaml
@@ -29,5 +29,5 @@ parameters:
     required: false
   extra_fields:
     type: object
-    description: extra fields like priority. example: {"priority": {"name": "P1"}, "customfield_10250": {"value": "General"}}'
+    description: "extra fields like priority, labels, custom fields, etc"
     required: false

--- a/packs/jira/actions/create_issue.yaml
+++ b/packs/jira/actions/create_issue.yaml
@@ -27,3 +27,7 @@ parameters:
     type: string
     description: destination Project in Jira.
     required: false
+  extra_fields:
+    type: object
+    description: extra fields like priority. example: {"priority": {"name": "P1"}, "customfield_10250": {"value": "General"}}'
+    required: false


### PR DESCRIPTION
the extra_fields option allow someone specify other fields for a jira issue, like priority, labels, custom fields, etc.

example:
```
st2 action execute jira.create_issue description="testando o st2" summary="st2 test ticket" extra_fields='{"priority": {"name": "P1"}, "customfield_10250": {"value": "General"}}'
```