### PR TITLE
Getting rid of immutable flag for sudo parameters in ansible pack

### DIFF
--- a/packs/ansible/CHANGES.md
+++ b/packs/ansible/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.3
+
+* Removed immutable flag for `sudo:` parameters for all actions. Default is `true`, which means that ansible commands are run with sudo (as root). Good thing is you can change it to `false` when required.
+
 ## v0.2
 
 * Breaking Change: Replaced all dashes in parameter names with underscores (adhere to the spec of Jinja/Python variables)

--- a/packs/ansible/actions/command.yaml
+++ b/packs/ansible/actions/command.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   cwd:
     description: "Working directory where the command will be executed in"
     type: string

--- a/packs/ansible/actions/command_local.yaml
+++ b/packs/ansible/actions/command_local.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   cwd:
     description: "Working directory where the command will be executed in"
     type: string

--- a/packs/ansible/actions/galaxy.install.yaml
+++ b/packs/ansible/actions/galaxy.install.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds"
     type: integer

--- a/packs/ansible/actions/galaxy.list.yaml
+++ b/packs/ansible/actions/galaxy.list.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/packs/ansible/actions/galaxy.remove.yaml
+++ b/packs/ansible/actions/galaxy.remove.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/packs/ansible/actions/playbook.yaml
+++ b/packs/ansible/actions/playbook.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   cwd:
     description: "Working directory where the command will be executed in"
     type: string

--- a/packs/ansible/actions/vault.decrypt.yaml
+++ b/packs/ansible/actions/vault.decrypt.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/packs/ansible/actions/vault.encrypt.yaml
+++ b/packs/ansible/actions/vault.encrypt.yaml
@@ -14,7 +14,6 @@ parameters:
     description: "Lock sudo, the behavior is controlled by ansible 'become_' options"
     type: boolean
     default: true
-    immutable: true
   timeout:
     description: "Action timeout in seconds. Action will get killed if it doesn't finish in timeout seconds. Lock as uneeded"
     type: integer

--- a/packs/ansible/pack.yaml
+++ b/packs/ansible/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.2
+version : 0.3
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
 - bumping version to 0.3
 - removing immutable flag for 'sudo' param of all actions