### PR TITLE
Add multiple queues support to AWS sqs sensor

### DIFF
--- a/packs/aws/CHANGES.md
+++ b/packs/aws/CHANGES.md
@@ -3,3 +3,11 @@
 ## v0.1.0
 
 * Initial release
+
+## v0.3.0
+
+* Add aws.sqs_sensor which can monitor given sqs queue and trigger aws.sqs_new_message
+
+## v0.4.0
+
+* Add support for handling multiple input_queues to aws.sqs_sensor

--- a/packs/aws/README.md
+++ b/packs/aws/README.md
@@ -86,7 +86,7 @@ Example trigger payload:
         "s3SchemaVersion": "1.0"
     }
 }
-````
+```
 
 ``source``, ``region``, ``name`` and ``timestamp`` attributes are included with
 all the events, but the format and values inside the ``payload`` attribute
@@ -94,6 +94,45 @@ different across different services and event types.
 
 For a list of supported S3 event types see
 http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-notification-event-types
+
+### AWS SQS sensor
+
+This is generic *SQS* Sensor using boto3 api to fetch messages from *SQS* queue.
+After receiving a message it's content is passed as payload to a trigger 'aws.sqs_new_message'
+
+This sensor can be configured either by using config.yaml within a pack or by creating
+following values in datastore:
+
+- aws.input_queues (list queues as comma separated string: first_queue,second_queue)
+- aws.aws_access_key_id
+- aws.aws_secret_access_key
+- aws.region
+
+For configuration in ``config.yaml`` with config like this
+
+```yaml
+    setup:
+      aws_access_key_id:
+      aws_access_key_id:
+      region:
+    sqs_sensor:
+      input_queues:
+        - first_queue
+        - second_queue
+```
+
+If any value exist in datastore it will be taken instead of any value in config.yaml
+
+#### aws.sqs\_new\_message
+
+This trigger is emitted when a single message is received from a queue.
+
+```json
+{
+  "queue": "first_sqs_queue",
+  "body": "example message body"
+}
+```
 
 ## Actions
 
@@ -282,3 +321,47 @@ http://docs.aws.amazon.com/AmazonS3/latest/dev/NotificationHowTo.html#supported-
 * ec2\_unmonitor\_instance
 * ec2\_unmonitor\_instances
 * ec2\_wait\_for\_state
+
+### SQS Actions
+
+* sqs\_add\_permission.yaml
+* sqs\_build\_base\_http\_request.yaml
+* sqs\_build\_complex\_list\_params.yaml
+* sqs\_build\_list\_params.yaml
+* sqs\_change\_message\_visibility.yaml
+* sqs\_change\_message\_visibility\_batch.yaml
+* sqs\_close.yaml
+* sqs\_create\_queue.yaml
+* sqs\_delete\_message.yaml
+* sqs\_delete\_message\_batch.yaml
+* sqs\_delete\_message\_from\_handle.yaml
+* sqs\_delete\_queue.yaml
+* sqs\_get\_all\_queues.yaml
+* sqs\_get\_dead\_letter\_source\_queues.yaml
+* sqs\_get\_http\_connection.yaml
+* sqs\_get\_list.yaml
+* sqs\_get\_object.yaml
+* sqs\_get\_path.yaml
+* sqs\_get\_proxy\_auth\_header.yaml
+* sqs\_get\_proxy\_url\_with\_auth.yaml
+* sqs\_get\_queue.yaml
+* sqs\_get\_queue\_attributes.yaml
+* sqs\_get\_status.yaml
+* sqs\_get\_utf8\_value.yaml
+* sqs\_handle\_proxy.yaml
+* sqs\_lookup.yaml
+* sqs\_make\_request.yaml
+* sqs\_new\_http\_connection.yaml
+* sqs\_prefix\_proxy\_to\_path.yaml
+* sqs\_proxy\_ssl.yaml
+* sqs\_purge\_queue.yaml
+* sqs\_put\_http\_connection.yaml
+* sqs\_receive\_message.yaml
+* sqs\_remove\_permission.yaml
+* sqs\_send\_message.yaml
+* sqs\_send\_message\_batch.yaml
+* sqs\_server\_name.yaml
+* sqs\_set\_host\_header.yaml
+* sqs\_set\_queue\_attribute.yaml
+* sqs\_set\_request\_hook.yaml
+* sqs\_skip\_proxy.yaml

--- a/packs/aws/config.yaml
+++ b/packs/aws/config.yaml
@@ -12,4 +12,4 @@ service_notifications_sensor:
   path: "/my-path"
 
 sqs_sensor:
-  input_queue: ""
+  input_queues:

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -11,6 +11,6 @@ keywords:
   - route53
   - cloud
 
-version : 0.3
+version : 0.4.0
 author : st2-dev
 email : info@stackstorm.com

--- a/packs/aws/requirements.txt
+++ b/packs/aws/requirements.txt
@@ -1,3 +1,4 @@
 boto
 # Note: boto3 is used by the SQS sensor
 boto3
+six

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -4,7 +4,7 @@ After receiving a message it's content is passed as payload to a trigger 'aws.sq
 
 This sensor can be configured either by using config.yaml withing a pack or by creating
 following values in datastore:
-    - aws.input_queue
+    - aws.input_queues (list queues as comma separrated string: first_queue,second_queue)
     - aws.aws_access_key_id
     - aws.aws_secret_access_key
     - aws.region
@@ -15,7 +15,9 @@ For configuration in config.yaml with config like this
       aws_access_key_id:
       region:
     sqs_sensor:
-      input_queue:
+      input_queues:
+        - first_queue
+        - second_queue
 
 If any value exist in datastore it will be taken instead of any value in config.yaml
 """
@@ -32,9 +34,17 @@ class AWSSQSSensor(PollingSensor):
                                            poll_interval=poll_interval)
 
     def setup(self):
-        self.input_queue = self._get_config_entry(key='keys ', prefix='sqs_sensor')
+        queues = self._get_config_entry(key='input_queues', prefix='sqs_sensor')
+
+        # XXX: This is a hack as from datastore we can only receive a string while
+        # from config.yaml we can receive a list
+        if type(queues) is str:
+            self.input_queues = queues.split(', ')
+        else:
+            self.input_queues = queues
+
         self.aws_access_key = self._get_config_entry('aws_access_key_id')
-        self.aws_secret_key = self._get_config_entry('aws_access_key_id')
+        self.aws_secret_key = self._get_config_entry('aws_secret_access_key')
         self.aws_region = self._get_config_entry('region')
 
         self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
@@ -43,14 +53,14 @@ class AWSSQSSensor(PollingSensor):
         self.sqs_res = None
 
         self._setup_sqs()
-        self.queue = self._get_queue_by_name(self.input_queue)
 
     def poll(self):
-        msg = self._receive_messages(queue=self.queue)
-        if msg:
-            payload = {"queue": self.input_queue, "body": msg[0].body}
-            self._sensor_service.dispatch(trigger="aws.sqs_new_message", payload=payload)
-            msg[0].delete()
+        for queue in self.input_queues:
+            msg = self._receive_messages(queue=self._get_queue_by_name(queue))
+            if msg:
+                payload = {"queue": queue, "body": msg[0].body}
+                self._sensor_service.dispatch(trigger="aws.sqs_new_message", payload=payload)
+                msg[0].delete()
 
     def cleanup(self):
         pass
@@ -73,6 +83,9 @@ class AWSSQSSensor(PollingSensor):
         value = self._sensor_service.get_value('aws.%s' % (key), local=False)
         if not value:
             value = config.get(key, None)
+
+        if not value:
+            raise ValueError('[AWSSQSSensor]: Configuration for %s key is missing.' % (key))
 
         return value
 

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -22,6 +22,7 @@ For configuration in config.yaml with config like this
 If any value exist in datastore it will be taken instead of any value in config.yaml
 """
 
+import six
 from boto3.session import Session
 from botocore.exceptions import ClientError
 
@@ -38,8 +39,8 @@ class AWSSQSSensor(PollingSensor):
 
         # XXX: This is a hack as from datastore we can only receive a string while
         # from config.yaml we can receive a list
-        if type(queues) is str:
-            self.input_queues = queues.split(', ')
+        if isinstance(queues, six.string_types):
+            self.input_queues = [x.strip() for x in queues.split(',')]
         else:
             self.input_queues = queues
 

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -2,9 +2,9 @@
 This is generic SQS Sensor using boto3 api to fetch messages from sqs queue.
 After receiving a message it's content is passed as payload to a trigger 'aws.sqs_new_message'
 
-This sensor can be configured either by using config.yaml withing a pack or by creating
+This sensor can be configured either by using config.yaml within a pack or by creating
 following values in datastore:
-    - aws.input_queues (list queues as comma separrated string: first_queue,second_queue)
+    - aws.input_queues (list queues as comma separated string: first_queue,second_queue)
     - aws.aws_access_key_id
     - aws.aws_secret_access_key
     - aws.region


### PR DESCRIPTION
Add support for multiple queues into sqs sensor to make sure we can work with multiple rules. Raise an error if we don't get any configuration from ds nor config.yaml