### PR TITLE
Update get_alerts.py

### DIFF
--- a/packs/newrelic/actions/get_alerts.py
+++ b/packs/newrelic/actions/get_alerts.py
@@ -8,7 +8,7 @@ class GetAppHealthStatusAction(Action):
     Get health status of new relic application(s).
     """
     def __init__(self, *args, **kwargs):
-        super(GetAppHealthStatusAction, Action).__init__(*args, **kwargs)
+        super(GetAppHealthStatusAction, self).__init__(*args, **kwargs)
         self.url = 'https://api.newrelic.com/v2/applications.json'
         self.headers = {
             'User-Agent': 'StackStorm-New-Relic-Sensor/1.0.0 python-requests/2.7.0',


### PR DESCRIPTION
Current super was causing a TypeError:

super(GetAppHealthStatusAction, Action).__init__(*args, **kwargs)
TypeError: super(type, obj): obj must be an instance or subtype of type

Changing to super(GetAppHealthStatusAction, self) resolves the issue and things are working correctly again.