### PR TITLE
Allow user to specify "cacert" config option in the st2 pack

### DIFF
--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -22,7 +22,14 @@ class St2BaseAction(Action):
     def _get_client(self):
         base_url, api_url = self._get_st2_urls()
         token = self._get_auth_token()
-        return self._client(base_url=base_url, api_url=api_url, token=token)
+        cacert = self._get_cacert()
+
+        client_kwargs = {}
+        if cacert:
+            client_kwargs['cacert'] = cacert
+
+        return self._client(base_url=base_url, api_url=api_url, token=token,
+                            **client_kwargs)
 
     def _get_st2_urls(self):
         # First try to use base_url from config.
@@ -46,6 +53,10 @@ class St2BaseAction(Action):
             token = os.environ.get('ST2_ACTION_AUTH_TOKEN', None)
 
         return token
+
+    def _get_cacert(self):
+        cacert = self.config.get('cacert', None)
+        return cacert
 
     def _run_client_method(self, method, method_kwargs, format_func, format_kwargs=None):
         """

--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -5,6 +5,10 @@ base_url: ""
 # configuration and will require a refresh.
 auth_token: ""
 
-# Path to the CA cert file (bundle) used when verifying client cert.
+# If this setting is provided, server cert validation will be performed.
+# By default, client assumes self-signed cert and doesn't perform cert
+# validation.
+# This value can either contain path to the CA_BUNDLE file with
+# certificates of trusted CAs or "True" to use CAs from system storage.
 # If not provided, no validation will be performed
 cacert: ""

--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -1,5 +1,10 @@
 ---
 base_url: ""
+
 # auth_token will expire per token_ttl specifed in stackstorm
 # configuration and will require a refresh.
 auth_token: ""
+
+# Path to the CA cert file (bundle) used when verifying client cert.
+# If not provided, no validation will be performed
+cacert: ""

--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -5,10 +5,10 @@ base_url: ""
 # configuration and will require a refresh.
 auth_token: ""
 
-# If this setting is provided, server cert validation will be performed.
-# By default, client assumes self-signed cert and doesn't perform cert
+# If this setting is provided, server certertificate validation is performed.
+# By default, client assumes self-signed cert and doesn't perform certificate
 # validation.
-# This value can either contain path to the CA_BUNDLE file with
-# certificates of trusted CAs or "True" to use CAs from system storage.
-# If not provided, no validation will be performed
+# This value can either contain path to the CA_BUNDLE file with certificates
+# of trusted CAs or "True" to use CAs from the system trust store. If not
+# provided, no validation is performed.
 cacert: ""


### PR DESCRIPTION
By default, if `cacert` option is not passed to the client constructor (current behavior), the client doesn't perform cert validation (https://github.com/StackStorm/st2/blob/master/st2client/st2client/utils/httpclient.py#L30).

If a user is using a cert issued by trusted CA authority or want to turn cert validation on they can do this by specifying `cacert` config option (either path to CA bundle or True to use CA from system store).