### PR TITLE
[WIP] Adding auth_url attribute

### DIFF
--- a/packs/st2/README.md
+++ b/packs/st2/README.md
@@ -13,6 +13,8 @@ Requires StackStorm >= `v0.8.0`
   is provided will assume the pack is expected to work with current StackStorm
   instance and pick up appropriate values from the actions environment. See
   http://docs.stackstorm.com/actions.html#common-environment-variables-available-to-the-actions
+* `api_url' - Base API url for the StackStorm API Server endpoint. (e.g.: https://localhost/api)
+* `auth_url' - Base AUTH url for the StackStorm Auth Server endpoint. (e.g.: https://localhost/auth)
 * `auth_token` - A negotiated auth token for the StackStorm endpoint specified
   in base_url. Note that this value will expire per the `token_ttl` specified
   in StackStorm configuration. See http://docs.stackstorm.com/authentication.html#usage

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -28,8 +28,8 @@ class St2BaseAction(Action):
     def _get_st2_urls(self):
         # First try to use base_url from config.
         base_url = self.config.get('base_url', None)
-        api_url = None
-        auth_url = None
+        api_url = self.config.get('api_url', None)
+        auth_url = self.config.get('auth_url', None)
 
         # not found look up from env vars. Assuming the pack is
         # configuered to work with current StackStorm instance.

--- a/packs/st2/actions/lib/action.py
+++ b/packs/st2/actions/lib/action.py
@@ -20,21 +20,24 @@ class St2BaseAction(Action):
         self.client = self._get_client()
 
     def _get_client(self):
-        base_url, api_url = self._get_st2_urls()
+        base_url, api_url, auth_url = self._get_st2_urls()
         token = self._get_auth_token()
-        return self._client(base_url=base_url, api_url=api_url, token=token)
+        return self._client(base_url=base_url, api_url=api_url,
+                            auth_url=auth_url, token=token)
 
     def _get_st2_urls(self):
         # First try to use base_url from config.
         base_url = self.config.get('base_url', None)
         api_url = None
+        auth_url = None
 
         # not found look up from env vars. Assuming the pack is
         # configuered to work with current StackStorm instance.
         if not base_url:
             api_url = os.environ.get('ST2_ACTION_API_URL', None)
+            auth_url = os.environ.get('ST2_ACTION_AUTH_URL', None)
 
-        return base_url, api_url
+        return base_url, api_url, auth_url
 
     def _get_auth_token(self):
         # First try to use auth_token from config.

--- a/packs/st2/config.yaml
+++ b/packs/st2/config.yaml
@@ -1,5 +1,6 @@
 ---
-base_url: ""
+api_url: ""
+auth_url: ""
 # auth_token will expire per token_ttl specifed in stackstorm
 # configuration and will require a refresh.
 auth_token: ""


### PR DESCRIPTION
This PR adds a new `auth_url` attribute to the `st2` base pack. This allows an overwrite to ensure that the both authentication and authorization URLs can be specified independently.

This is to accommodate the move of the endpoints to subdirectories in the AIO versus individual ports.

Working with Justin in #stackstorm-community.