### PR TITLE
AWS pack formatter fixes

### DIFF
--- a/packs/aws/CHANGES.rst
+++ b/packs/aws/CHANGES.rst
@@ -1,0 +1,10 @@
+## v0.6.0
+
+* Fix the result format of some of the actions such as ``ec2_run_instances``. Previously,
+  the result was a list of lists of dicts and now the result is correctly a list of dicts.
+
+  Keep in mind that this is a breaking changes.
+
+  If you previously accessed the result of the ``ec2_run_instances`` action in the action-chain
+  workflow like that - ``run_instances.result[0][0].id``, you need to update it so it looks like
+  this ``run_instance.result[0].id``.

--- a/packs/aws/actions/lib/action.py
+++ b/packs/aws/actions/lib/action.py
@@ -92,7 +92,8 @@ class BaseAction(Action):
             del self.setup['region']
             obj = getattr(module, cls)(**self.setup)
         resultset = getattr(obj, action)(**kwargs)
-        return self.resultsets.formatter(resultset)
+        formatted = self.resultsets.formatter(resultset)
+        return formatted if isinstance(formatted, list) else [formatted]
 
     def do_function(self, module_path, action, **kwargs):
         module = __import__(module_path)

--- a/packs/aws/actions/lib/ec2parsers.py
+++ b/packs/aws/actions/lib/ec2parsers.py
@@ -148,13 +148,12 @@ class ResultSets(object):
             return output
 
     def formatter(self, output):
-        formatted = []
         if isinstance(output, list):
-            for o in output:
-                formatted.append(self.selector(o))
+            return [self.formatter(item) for item in output]
+        elif isinstance(output, dict):
+            return {key: self.formatter(value) for key, value in six.iteritems(output)}
         else:
-            formatted.append(self.selector(output))
-        return formatted
+            return self.selector(output)
 
     def parseReservation(self, output):
         instance_list = []

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -17,6 +17,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.5.0
+version : 0.6.0
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
This pull request adds back changes from #386 which were previously reverted to get things working.

In addition to that it also adds changes file where this backward incompatible change is described. I will also add a knowledge base entry which points to this change file. We should link users to that entry in case this encounter this issue after this change has been merged.

Note: We should only merge this after v1.3.1 is out.