### PR TITLE
Add environment parameter to puppet.run_agent

### DIFF
--- a/packs/puppet/actions/run_agent.py
+++ b/packs/puppet/actions/run_agent.py
@@ -18,7 +18,7 @@ class PuppetRunAgentAction(PuppetBaseAction):
             args += ['--server=%s' % (server)]
 
         if certname:
-            args += ['--certname=%s' % (server)]
+            args += ['--certname=%s' % (certname)]
 
         if daemonize:
             args += ['--daemonize']

--- a/packs/puppet/actions/run_agent.py
+++ b/packs/puppet/actions/run_agent.py
@@ -10,8 +10,8 @@ __all__ = [
 
 
 class PuppetRunAgentAction(PuppetBaseAction):
-    def run(self, server=None, certname=None, daemonize=False, onetime=True,
-            debug=None):
+    def run(self, server=None, certname=None, environment=None,
+            daemonize=False, onetime=True, debug=None):
         args = ['agent']
 
         if server:
@@ -19,6 +19,9 @@ class PuppetRunAgentAction(PuppetBaseAction):
 
         if certname:
             args += ['--certname=%s' % (certname)]
+
+        if environment:
+            args += ['--environment=%s' % (environment)]
 
         if daemonize:
             args += ['--daemonize']
@@ -41,6 +44,7 @@ if __name__ == '__main__':
                         required=False)
     parser.add_argument('--certname', help='Certname (unique ID) of the client',
                         required=False)
+    parser.add_argument('--environment', help='Environment to use in puppet run'),
     parser.add_argument('--daemonize', help='Send the process into the background',
                         action='store_true', default=False, required=False)
     parser.add_argument('--onetime', help='Use one time run mode',

--- a/packs/puppet/actions/run_agent.yaml
+++ b/packs/puppet/actions/run_agent.yaml
@@ -11,6 +11,9 @@ parameters:
   certname:
     type: string
     description: Certname (unique ID) of the client.
+  environment:
+    type: string
+    description: Environment to use in puppet run.
   daemonize:
     type: boolean
     description: Send the process into the background.

--- a/packs/puppet/pack.yaml
+++ b/packs/puppet/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - puppet
   - cfg management
   - configuration management
-version : 0.1
+version : 0.2
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
This parameter allows to specify the environment to be used in a puppet agent run.

* Bugfix? dd92c77  `certname` wrongly used the value of `server`