### PR TITLE
Add BitBucket post_receive_webhook rule for autodeployment of commits

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,6 @@ nosetests.xml
 .DS_Store
 ._*
 
+# Editor Saves
+*~
+\#*\#

--- a/packs/bitbucket/README.md
+++ b/packs/bitbucket/README.md
@@ -193,7 +193,9 @@ This has a number of pre-dependancies:
 
 - Setting an Workflow / Hooks / Post-Receive WebHooks pointing at the URL
 
-```https://<my-server>/api/v1/webhooks/bitbucket_post_receive?st2-api-key=<ST2-API-Key```
+```
+https://<my-server>/api/v1/webhooks/bitbucket_post_receive?st2-api-key=<ST2-API-Key
+```
 
 *Important:* The BitBucket server (or cloud) needs to be able to reach
 your StackStorm server and considers the SSL cert as valid. The

--- a/packs/bitbucket/README.md
+++ b/packs/bitbucket/README.md
@@ -194,7 +194,7 @@ This has a number of pre-dependancies:
 - Setting an Workflow / Hooks / Post-Receive WebHooks pointing at the URL
 
 ```
-https://<my-server>/api/v1/webhooks/bitbucket_post_receive?st2-api-key=<ST2-API-Key
+https://<my-server>/api/v1/webhooks/bitbucket_post_receive?st2-api-key=<ST2-API-Key>
 ```
 
 *Important:* The BitBucket server (or cloud) needs to be able to reach

--- a/packs/bitbucket/README.md
+++ b/packs/bitbucket/README.md
@@ -197,6 +197,12 @@ This has a number of pre-dependancies:
 https://<my-server>/api/v1/webhooks/bitbucket_post_receive?st2-api-key=<ST2-API-Key>
 ```
 
+- The rule is disabled by default and needs to be enabled with
+
+```bash
+st2 rule enable bitbucket.post_receive_webhook
+```
+
 *Important:* The BitBucket server (or cloud) needs to be able to reach
 your StackStorm server and considers the SSL cert as valid. The
 `ST2-API-Key` should be genrated as per the instructions at

--- a/packs/bitbucket/README.md
+++ b/packs/bitbucket/README.md
@@ -175,3 +175,27 @@ Usage:
 ```bash
 st2 run bitbucket.list_branches repo="<repo_name>"
 ```
+
+## Rules
+
+### Post-Receive WebHook
+
+This rule triggers packs.deploy (in ST2 v1.4+) to allow
+auto-deployment of single pack repository.
+
+This has a number of pre-dependancies:
+
+- The repository being configured in:
+
+```bash
+/opt/stackstorm/packs/packs/config.yaml
+```
+
+- Setting an Workflow / Hooks / Post-Receive WebHooks pointing at the URL
+
+```https://<my-server>/api/v1/webhooks/bitbucket_post_receive?st2-api-key=<ST2-API-Key```
+
+*Important:* The BitBucket server (or cloud) needs to be able to reach
+your StackStorm server and considers the SSL cert as valid. The
+`ST2-API-Key` should be genrated as per the instructions at
+https://docs.stackstorm.com/authentication.html.

--- a/packs/bitbucket/pack.yaml
+++ b/packs/bitbucket/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - mercuriral
   - git
   - source control
-version: 0.1.0
+version: 0.1.1
 author: Aamir
 email: raza.aamir01@gmail.com

--- a/packs/bitbucket/rules/post_receive_webhook.yaml
+++ b/packs/bitbucket/rules/post_receive_webhook.yaml
@@ -1,0 +1,25 @@
+---
+name: "post_receive_webhook"
+pack: "bitbucket"
+description: "Trigger ST2 pack deploy for commit on Git branch"
+enabled: true
+
+trigger:
+  type: "core.st2.webhook"
+  parameters:
+    url: "bitbucket_post_receive"
+
+criteria:
+  trigger.body:
+    pattern: "changesets"
+    type: "exists"
+
+action:
+  ref: "packs.deploy"
+  parameters:
+    auto_deploy: true
+    repo_name:  "{{trigger.body.repository.name}}"
+    branch:     "{{trigger.body.refChanges[0].refId}}"
+    packs:      [ "{{trigger.body.repository.name}}" ]
+    message:    "{{trigger.body.changesets.get('values')[0].toCommit.message}}"
+    author:     "{{trigger.body.changesets.get('values')[0].toCommit.author.name}}"

--- a/packs/bitbucket/rules/post_receive_webhook.yaml
+++ b/packs/bitbucket/rules/post_receive_webhook.yaml
@@ -2,7 +2,7 @@
 name: "post_receive_webhook"
 pack: "bitbucket"
 description: "Trigger ST2 pack deploy for commit on Git branch"
-enabled: true
+enabled: false
 
 trigger:
   type: "core.st2.webhook"


### PR DESCRIPTION
## BitBucket

### Status 

- pack extension, complete

### Description

- Add `rules/post_receive_webhook.yaml` which calls packs.deploy that was added in PR#????
- Add emacs editor saves to .gitignore
- Document new rule in README.md.

### Checklist (tick everything that applies)

- [X] Metadata: pack.yaml, icon, structure (required for new packs)
- [X] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)
