### PR TITLE
[salt] Prevent premature args to list coersion

### DIFF
--- a/packs/salt/actions/lib/base.py
+++ b/packs/salt/actions/lib/base.py
@@ -56,7 +56,7 @@ class SaltAction(Action):
         if kwargs.get('kwargs', None) is not None:
             self.data['kwarg'] = kwargs['kwargs']['kwargs']
         if args is not None:
-            self.data['arg'] = args
+            self.data['arg'] = list(args)
         clean_payload = sanitize_payload(('username', 'password'), self.data)
         self.logger.info("[salt] Payload to be sent: {0}".format(clean_payload))
 

--- a/packs/salt/actions/local.py
+++ b/packs/salt/actions/local.py
@@ -29,7 +29,7 @@ class SaltLocal(SaltAction):
         '''
         self.generate_package('local',
                               cmd=module,
-                              args=list(args),
+                              args=args,
                               target=target,
                               expr_form=expr_form,
                               data=kwargs)

--- a/packs/salt/pack.yaml
+++ b/packs/salt/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version : 0.4
+version : 0.4.1
 author : jcockhren
 email : jurnell@sophicware.com


### PR DESCRIPTION
## Salt

### Status 

- bugfix

### Description

This PR fixes a issue introduced in #425 where `args` supplied to the action call where coerced to a `list` before checking if `args is None` (meaning it wasn't supplied with the action call). This causes:

1. failure in `local.py` because `list(args)` throws exception when `args` is `None`.
2. Supplying an empty `args` at during action call causes failure for any execution module that doesn't accept positional `args`

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)

@tonybaloney @emedvedev 