### PR TITLE
Fix an execution list bug in the `st2` pack

### DIFF
--- a/packs/st2/aliases/executions_list.yaml
+++ b/packs/st2/aliases/executions_list.yaml
@@ -12,5 +12,5 @@ result:
     format: |
         Found {{ execution.result.result | length }} executions:{~}
         {% for exe in execution.result.result -%}
-            • `{{ exe.id }}` for `{{ exe.action.ref }}`: {{ exe.status }}, started at {{ exe.start_timestamp[:19]|replace("T", " ") }}{% if exe.end_timestamp %}, finished at {{ exe.start_timestamp[:19]|replace("T", " ") }}{% endif %}.
+            • `{{ exe.id }}` for `{{ exe.action.ref }}`: {{ exe.status }}, started at {{ exe.start_timestamp[:19]|replace("T", " ") }}{% if 'end_timestamp' in exe %}, finished at {{ exe.end_timestamp[:19]|replace("T", " ") }}{% endif %}.
         {%+ endfor %}

--- a/packs/st2/pack.yaml
+++ b/packs/st2/pack.yaml
@@ -2,6 +2,6 @@
 ---
 name: st2
 description: StackStorm pack management
-version: 0.1.1
+version: 0.1.2
 author: st2-dev
 email: info@stackstorm.com


### PR DESCRIPTION
The issue was reported via e-mail by Jonathon Adler.

The `st2` pack has a bug where trying to list pending executions would
result in an error.