### PR TITLE
Allow multiple exclamation marks while honking Tesla

### DIFF
--- a/packs/tesla/aliases/honk_horn.yaml
+++ b/packs/tesla/aliases/honk_horn.yaml
@@ -3,8 +3,11 @@ name: "tesla.honk_horn"
 action_ref: "tesla.honk_horn"
 description: "Honk your horn"
 formats:
-   - display: "honk-honk {{vin}}"
-     representation:
-       - "((beep|honk|meep)-?)+ {{vin}}[!.]*"
+    - display: "honk-honk"
+      representation:
+        - "((beep|honk|meep)-?)+[!.]*"
+    - display: "honk-honk {{vin}}"
+      representation:
+        - "((beep|honk|meep)-?)+ {{vin}}[!.]*"
 result:
     format: "{~}**Honk Honk**"

--- a/packs/tesla/aliases/honk_horn.yaml
+++ b/packs/tesla/aliases/honk_horn.yaml
@@ -5,6 +5,6 @@ description: "Honk your horn"
 formats:
    - display: "honk-honk {{vin}}"
      representation:
-       - "((beep|honk|meep)-?)+ {{vin}}[!.]?"
+       - "((beep|honk|meep)-?)+ {{vin}}[!.]*"
 result:
     format: "{~}**Honk Honk**"

--- a/packs/tesla/pack.yaml
+++ b/packs/tesla/pack.yaml
@@ -3,6 +3,6 @@ name : tesla
 description : car horn automation
 keywords:
   - tesla
-version : 0.1
+version : 0.1.1
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com

--- a/packs/tesla/pack.yaml
+++ b/packs/tesla/pack.yaml
@@ -3,6 +3,6 @@ name : tesla
 description : car horn automation
 keywords:
   - tesla
-version : 0.1.1
+version : 0.2.0
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com


### PR DESCRIPTION
Since honking is a very emotional process, and people often have to
channel their intense feelings into it, it makes very little sense to
have a `?` quantifier in the honking alias: that would only allow for a
mere `honk-honk`, or a brief exclamative `honk-honk!`.

Changing the quantifier to `*` gives people the chance to express all
the feelings they want to express. Honk-honk!!!!!!!!!!!!!!!!!!!!!!!