### PR TITLE
Update rules to use correct trigger name

### DIFF
--- a/packs/nagios/pack.yaml
+++ b/packs/nagios/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - nagios
   - monitoring
   - alerting
-version : 0.1
+version : 0.2
 author : st2-dev
 email : info@stackstorm.com

--- a/packs/nagios/rules/nagios_service_chat.yaml
+++ b/packs/nagios/rules/nagios_service_chat.yaml
@@ -4,7 +4,7 @@ pack: nagios
 description: Post to chat when nagios service state changes
 enabled: true
 trigger:
-  type: nagios.service.state_change
+  type: nagios.service-state-change
 criteria:
   trigger.attempt:
     pattern: 2

--- a/packs/nagios/rules/nagios_service_load.yaml
+++ b/packs/nagios/rules/nagios_service_load.yaml
@@ -4,7 +4,7 @@ pack: nagios
 description: Check cpu load on host
 enabled: true
 trigger:
-  type: nagios.service.state_change
+  type: nagios.service-state-change
 criteria:
   trigger.service:
     pattern: "(.*)_check_loadavg"

--- a/packs/nagios/rules/nagios_service_load_procd.yaml
+++ b/packs/nagios/rules/nagios_service_load_procd.yaml
@@ -4,7 +4,7 @@ pack: nagios
 description: Check D state procs on host when load is high
 enabled: true
 trigger:
-  type: nagios.service.state_change
+  type: nagios.service-state-change
 criteria:
   trigger.service:
     pattern: "(.*)_check_loadavg"

--- a/packs/nagios/rules/nagios_service_load_procr.yaml
+++ b/packs/nagios/rules/nagios_service_load_procr.yaml
@@ -4,7 +4,7 @@ pack: nagios
 description: Check running procs on host when load is high
 enabled: true
 trigger:
-  type: nagios.service.state_change
+  type: nagios.service-state-change
 criteria:
   trigger.service:
     pattern: "(.*)_check_loadavg"

--- a/packs/nagios/rules/nagios_service_mail.yaml
+++ b/packs/nagios/rules/nagios_service_mail.yaml
@@ -4,7 +4,7 @@ pack: nagios
 description: Send mail when nagios service state changes
 enabled: true
 trigger:
-  type: nagios.service.state_change
+  type: nagios.service-state-change
 criteria: {}
 action:
   ref: send_mail

--- a/packs/nagios/rules/nagios_service_proc.yaml
+++ b/packs/nagios/rules/nagios_service_proc.yaml
@@ -4,7 +4,7 @@ pack: nagios
 description: Check process state on host
 enabled: true
 trigger:
-  type: st2.nagios.service.state_change
+  type: nagios.service-state-change
 criteria:
   service:
     pattern: "(.*)_check_(.*)_process"


### PR DESCRIPTION
## Pack nagios

### Status 

Just a simple bugfix to make the trigger name referenced in the nagios rules match the trigger name that is actually registered.
### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [X] Version bump (required for changed packs)
- [X] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)
