### PR TITLE
Fix pip typo in `duo` requirements

### DIFF
--- a/packs/duo/requirements.txt
+++ b/packs/duo/requirements.txt
@@ -1,1 +1,1 @@
-duo_client=0.1.2
+duo_client==0.1.2


### PR DESCRIPTION
Totally overlooked that. :) The pack won’t install without the fix because the syntax is incorrect.