### PR TITLE
Update requirements.txt for Duo Pack

### DIFF
--- a/packs/duo/requirements.txt
+++ b/packs/duo/requirements.txt
@@ -1,1 +1,1 @@
-duo_client==0.1.2
+duo_client==3.0


### PR DESCRIPTION
## Duo

### Status 

- bugfix

### Description

Not currenlty possible to install via `st2 run packs.install packs=duo` as the version is invalid, so change version to one that's valid and on PIP.

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [ ] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)

