### PR TITLE
Update documentation on how to use instance IAM roles and set Defaults

### DIFF
--- a/packs/aws/README.md
+++ b/packs/aws/README.md
@@ -20,6 +20,17 @@ You can generate the access key and secret access key by following these directi
 
 http://docs.aws.amazon.com/IAM/latest/UserGuide/ManagingCredentials.html#Using_CreateAccessKey
 
+If you would like to use the IAM role assigned to the instance stackstorm is running set the key and secret to null and set the region.
+```yaml
+---
+setup:
+  region: "us-east-1"
+  aws_access_key_id: null
+  aws_secret_access_key: null
+interval: 20
+st2_user_data: ""
+ ```
+
 * ``service_notifications_sensor.host`` - Listen host for the HTTP interface.
 * ``service_notifications_sensor.port`` - Listen path for the HTTP interface.
 * ``service_notifications_sensor.path`` - Path where the events need to be sent.

--- a/packs/aws/config.yaml
+++ b/packs/aws/config.yaml
@@ -1,8 +1,8 @@
 ---
 setup:
-  region: ""
-  aws_access_key_id: ""
-  aws_secret_access_key: ""
+  region: "us-east-1"
+  aws_access_key_id: null
+  aws_secret_access_key: null
 interval: 20
 st2_user_data: "/opt/stackstorm/packs/aws/actions/scripts/bootstrap_user.sh"
 

--- a/packs/aws/config.yaml
+++ b/packs/aws/config.yaml
@@ -1,6 +1,6 @@
 ---
 setup:
-  region: "us-east-1"
+  region: ""
   aws_access_key_id: null
   aws_secret_access_key: null
 interval: 20

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -17,6 +17,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.6.0
+version : 0.6.1
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
## AWS

### Status 

- Documentation update and set defaults

### Description

This updates the documentation to allow the AWS pack to use instance IAM role and also sets the defaults in the config.yaml to use US-EAST-1 and Instance IAM role for connections, this will allow it to work out of the box for anyone in running in US-EAST-1 with a meaningful role assigned. 

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [ *] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)
