### PR TITLE
use *array* for cloudformation parameters and capabilities.

### DIFF
--- a/packs/aws/actions/cf_create_stack.yaml
+++ b/packs/aws/actions/cf_create_stack.yaml
@@ -8,7 +8,7 @@ parameters:
     immutable: true
     type: string
   capabilities:
-    type: string
+    type: array
   cls:
     default: CloudFormationConnection
     immutable: true
@@ -24,7 +24,7 @@ parameters:
   on_failure:
     type: string
   parameters:
-    type: string
+    type: array
   stack_name:
     required: true
     type: string

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -17,6 +17,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.6.0
+version : 0.6.1
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
## Pack AWS

### Status  
- bugfix

### Description
Cloudformation create_stack function expects a list as shown here:
https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/cloudformation/connection.py#L157
https://github.com/boto/boto/blob/d9e5cfe900e1a58717e393c76a6e3580305f217a/boto/cloudformation/connection.py#L341