### PR TITLE
[salt] Hotfix/missing target args

### DIFF
--- a/packs/salt/actions/local_archive.gunzip.yaml
+++ b/packs/salt/actions/local_archive.gunzip.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.gunzip.yaml
+++ b/packs/salt/actions/local_archive.gunzip.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.gunzip
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_archive.gzip.yaml
+++ b/packs/salt/actions/local_archive.gzip.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.gzip.yaml
+++ b/packs/salt/actions/local_archive.gzip.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.gzip
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_archive.rar.yaml
+++ b/packs/salt/actions/local_archive.rar.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.rar.yaml
+++ b/packs/salt/actions/local_archive.rar.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.rar
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_archive.tar.yaml
+++ b/packs/salt/actions/local_archive.tar.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.tar.yaml
+++ b/packs/salt/actions/local_archive.tar.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.tar
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_archive.unrar.yaml
+++ b/packs/salt/actions/local_archive.unrar.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.unrar.yaml
+++ b/packs/salt/actions/local_archive.unrar.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.unrar
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_archive.unzip.yaml
+++ b/packs/salt/actions/local_archive.unzip.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.unzip.yaml
+++ b/packs/salt/actions/local_archive.unzip.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.unzip
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_archive.zip_.yaml
+++ b/packs/salt/actions/local_archive.zip_.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_archive.zip_.yaml
+++ b/packs/salt/actions/local_archive.zip_.yaml
@@ -8,6 +8,14 @@ parameters:
     default: archive.zip_
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.action.yaml
+++ b/packs/salt/actions/local_cloud.action.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.action.yaml
+++ b/packs/salt/actions/local_cloud.action.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.action
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.create.yaml
+++ b/packs/salt/actions/local_cloud.create.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.create.yaml
+++ b/packs/salt/actions/local_cloud.create.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.create
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.destroy.yaml
+++ b/packs/salt/actions/local_cloud.destroy.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.destroy.yaml
+++ b/packs/salt/actions/local_cloud.destroy.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.destroy
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.network_create.yaml
+++ b/packs/salt/actions/local_cloud.network_create.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.network_create.yaml
+++ b/packs/salt/actions/local_cloud.network_create.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.network_create
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.profile_.yaml
+++ b/packs/salt/actions/local_cloud.profile_.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.profile_.yaml
+++ b/packs/salt/actions/local_cloud.profile_.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.profile_
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.virtual_interface_create.yaml
+++ b/packs/salt/actions/local_cloud.virtual_interface_create.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.virtual_interface_create.yaml
+++ b/packs/salt/actions/local_cloud.virtual_interface_create.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.virtual_interface_create
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.volume_attach.yaml
+++ b/packs/salt/actions/local_cloud.volume_attach.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.volume_attach
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.volume_attach.yaml
+++ b/packs/salt/actions/local_cloud.volume_attach.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.volume_create.yaml
+++ b/packs/salt/actions/local_cloud.volume_create.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.volume_create.yaml
+++ b/packs/salt/actions/local_cloud.volume_create.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.volume_create
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.volume_delete.yaml
+++ b/packs/salt/actions/local_cloud.volume_delete.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cloud.volume_delete.yaml
+++ b/packs/salt/actions/local_cloud.volume_delete.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.volume_delete
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.volume_detach.yaml
+++ b/packs/salt/actions/local_cloud.volume_detach.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cloud.volume_detach
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cloud.volume_detach.yaml
+++ b/packs/salt/actions/local_cloud.volume_detach.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cmdmod.run.yaml
+++ b/packs/salt/actions/local_cmdmod.run.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cmdmod.run.yaml
+++ b/packs/salt/actions/local_cmdmod.run.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cmdmod.run
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cmdmod.run_chroot.yaml
+++ b/packs/salt/actions/local_cmdmod.run_chroot.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cmdmod.run_chroot.yaml
+++ b/packs/salt/actions/local_cmdmod.run_chroot.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cmdmod.run_chroot
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cmdmod.script.yaml
+++ b/packs/salt/actions/local_cmdmod.script.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cmdmod.script.yaml
+++ b/packs/salt/actions/local_cmdmod.script.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cmdmod.script
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cp.get_file.yaml
+++ b/packs/salt/actions/local_cp.get_file.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cp.get_file.yaml
+++ b/packs/salt/actions/local_cp.get_file.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cp.get_file
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cp.get_url.yaml
+++ b/packs/salt/actions/local_cp.get_url.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cp.get_url.yaml
+++ b/packs/salt/actions/local_cp.get_url.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cp.get_url
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cp.push.yaml
+++ b/packs/salt/actions/local_cp.push.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cp.push.yaml
+++ b/packs/salt/actions/local_cp.push.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cp.push
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cp.push_dir.yaml
+++ b/packs/salt/actions/local_cp.push_dir.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cp.push_dir.yaml
+++ b/packs/salt/actions/local_cp.push_dir.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cp.push_dir
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cron.ls.yaml
+++ b/packs/salt/actions/local_cron.ls.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cron.ls
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cron.ls.yaml
+++ b/packs/salt/actions/local_cron.ls.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cron.rm_env.yaml
+++ b/packs/salt/actions/local_cron.rm_env.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cron.rm_env
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cron.rm_env.yaml
+++ b/packs/salt/actions/local_cron.rm_env.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cron.rm_job.yaml
+++ b/packs/salt/actions/local_cron.rm_job.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cron.rm_job.yaml
+++ b/packs/salt/actions/local_cron.rm_job.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cron.rm_job
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cron.set_env.yaml
+++ b/packs/salt/actions/local_cron.set_env.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_cron.set_env.yaml
+++ b/packs/salt/actions/local_cron.set_env.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cron.set_env
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cron.set_job.yaml
+++ b/packs/salt/actions/local_cron.set_job.yaml
@@ -8,6 +8,14 @@ parameters:
     default: cron.set_job
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_cron.set_job.yaml
+++ b/packs/salt/actions/local_cron.set_job.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_data.cas.yaml
+++ b/packs/salt/actions/local_data.cas.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_data.cas.yaml
+++ b/packs/salt/actions/local_data.cas.yaml
@@ -8,6 +8,14 @@ parameters:
     default: data.cas
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_data.dump.yaml
+++ b/packs/salt/actions/local_data.dump.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_data.dump.yaml
+++ b/packs/salt/actions/local_data.dump.yaml
@@ -8,6 +8,14 @@ parameters:
     default: data.dump
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_data.getval.yaml
+++ b/packs/salt/actions/local_data.getval.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_data.getval.yaml
+++ b/packs/salt/actions/local_data.getval.yaml
@@ -8,6 +8,14 @@ parameters:
     default: data.getval
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_data.update.yaml
+++ b/packs/salt/actions/local_data.update.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_data.update.yaml
+++ b/packs/salt/actions/local_data.update.yaml
@@ -8,6 +8,14 @@ parameters:
     default: data.update
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_event.fire.yaml
+++ b/packs/salt/actions/local_event.fire.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_event.fire.yaml
+++ b/packs/salt/actions/local_event.fire.yaml
@@ -8,6 +8,14 @@ parameters:
     default: event.fire
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_event.fire_master.yaml
+++ b/packs/salt/actions/local_event.fire_master.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_event.fire_master.yaml
+++ b/packs/salt/actions/local_event.fire_master.yaml
@@ -8,6 +8,14 @@ parameters:
     default: event.fire_master
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_event.send.yaml
+++ b/packs/salt/actions/local_event.send.yaml
@@ -8,6 +8,14 @@ parameters:
     default: event.send
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_event.send.yaml
+++ b/packs/salt/actions/local_event.send.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.access.yaml
+++ b/packs/salt/actions/local_file.access.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.access
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.access.yaml
+++ b/packs/salt/actions/local_file.access.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.chgrp.yaml
+++ b/packs/salt/actions/local_file.chgrp.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.chgrp.yaml
+++ b/packs/salt/actions/local_file.chgrp.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.chgrp
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.chown.yaml
+++ b/packs/salt/actions/local_file.chown.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.chown.yaml
+++ b/packs/salt/actions/local_file.chown.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.chown
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.directory_exists.yaml
+++ b/packs/salt/actions/local_file.directory_exists.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.directory_exists.yaml
+++ b/packs/salt/actions/local_file.directory_exists.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.directory_exists
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.file_exists.yaml
+++ b/packs/salt/actions/local_file.file_exists.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.file_exists.yaml
+++ b/packs/salt/actions/local_file.file_exists.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.file_exists
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.find.yaml
+++ b/packs/salt/actions/local_file.find.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.find.yaml
+++ b/packs/salt/actions/local_file.find.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.find
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.manage_file.yaml
+++ b/packs/salt/actions/local_file.manage_file.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.manage_file.yaml
+++ b/packs/salt/actions/local_file.manage_file.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.manage_file
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.mkdir.yaml
+++ b/packs/salt/actions/local_file.mkdir.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.mkdir.yaml
+++ b/packs/salt/actions/local_file.mkdir.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.mkdir
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.remove.yaml
+++ b/packs/salt/actions/local_file.remove.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.remove.yaml
+++ b/packs/salt/actions/local_file.remove.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.remove
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.replace.yaml
+++ b/packs/salt/actions/local_file.replace.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.replace.yaml
+++ b/packs/salt/actions/local_file.replace.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.replace
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.search.yaml
+++ b/packs/salt/actions/local_file.search.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.search.yaml
+++ b/packs/salt/actions/local_file.search.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.search
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.symlink.yaml
+++ b/packs/salt/actions/local_file.symlink.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.symlink.yaml
+++ b/packs/salt/actions/local_file.symlink.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.symlink
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.touch.yaml
+++ b/packs/salt/actions/local_file.touch.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.touch.yaml
+++ b/packs/salt/actions/local_file.touch.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.touch
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_file.truncate.yaml
+++ b/packs/salt/actions/local_file.truncate.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_file.truncate.yaml
+++ b/packs/salt/actions/local_file.truncate.yaml
@@ -8,6 +8,14 @@ parameters:
     default: file.truncate
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_grains.append.yaml
+++ b/packs/salt/actions/local_grains.append.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_grains.append.yaml
+++ b/packs/salt/actions/local_grains.append.yaml
@@ -8,6 +8,14 @@ parameters:
     default: grains.append
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_grains.delval.yaml
+++ b/packs/salt/actions/local_grains.delval.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_grains.delval.yaml
+++ b/packs/salt/actions/local_grains.delval.yaml
@@ -8,6 +8,14 @@ parameters:
     default: grains.delval
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_grains.get.yaml
+++ b/packs/salt/actions/local_grains.get.yaml
@@ -8,6 +8,14 @@ parameters:
     default: grains.get
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_grains.get.yaml
+++ b/packs/salt/actions/local_grains.get.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_grains.remove.yaml
+++ b/packs/salt/actions/local_grains.remove.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_grains.remove.yaml
+++ b/packs/salt/actions/local_grains.remove.yaml
@@ -8,6 +8,14 @@ parameters:
     default: grains.remove
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_grains.setval.yaml
+++ b/packs/salt/actions/local_grains.setval.yaml
@@ -8,6 +8,14 @@ parameters:
     default: grains.setval
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_grains.setval.yaml
+++ b/packs/salt/actions/local_grains.setval.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_hosts.add_hosts.yaml
+++ b/packs/salt/actions/local_hosts.add_hosts.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_hosts.add_hosts.yaml
+++ b/packs/salt/actions/local_hosts.add_hosts.yaml
@@ -8,6 +8,14 @@ parameters:
     default: hosts.add_hosts
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_hosts.get_alias.yaml
+++ b/packs/salt/actions/local_hosts.get_alias.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_hosts.get_alias.yaml
+++ b/packs/salt/actions/local_hosts.get_alias.yaml
@@ -8,6 +8,14 @@ parameters:
     default: hosts.get_alias
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_hosts.get_ip.yaml
+++ b/packs/salt/actions/local_hosts.get_ip.yaml
@@ -8,6 +8,14 @@ parameters:
     default: hosts.get_ip
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_hosts.get_ip.yaml
+++ b/packs/salt/actions/local_hosts.get_ip.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_hosts.rm_host.yaml
+++ b/packs/salt/actions/local_hosts.rm_host.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_hosts.rm_host.yaml
+++ b/packs/salt/actions/local_hosts.rm_host.yaml
@@ -8,6 +8,14 @@ parameters:
     default: hosts.rm_host
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_hosts.set_host.yaml
+++ b/packs/salt/actions/local_hosts.set_host.yaml
@@ -8,6 +8,14 @@ parameters:
     default: hosts.set_host
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_hosts.set_host.yaml
+++ b/packs/salt/actions/local_hosts.set_host.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_htpasswd.useradd.yaml
+++ b/packs/salt/actions/local_htpasswd.useradd.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_htpasswd.useradd.yaml
+++ b/packs/salt/actions/local_htpasswd.useradd.yaml
@@ -8,6 +8,14 @@ parameters:
     default: htpasswd.useradd
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_htpasswd.userdel.yaml
+++ b/packs/salt/actions/local_htpasswd.userdel.yaml
@@ -8,6 +8,14 @@ parameters:
     default: htpasswd.userdel
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_htpasswd.userdel.yaml
+++ b/packs/salt/actions/local_htpasswd.userdel.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_mine.delete.yaml
+++ b/packs/salt/actions/local_mine.delete.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_mine.delete.yaml
+++ b/packs/salt/actions/local_mine.delete.yaml
@@ -8,6 +8,14 @@ parameters:
     default: mine.delete
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_mine.get.yaml
+++ b/packs/salt/actions/local_mine.get.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_mine.get.yaml
+++ b/packs/salt/actions/local_mine.get.yaml
@@ -8,6 +8,14 @@ parameters:
     default: mine.get
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_mine.send.yaml
+++ b/packs/salt/actions/local_mine.send.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_mine.send.yaml
+++ b/packs/salt/actions/local_mine.send.yaml
@@ -8,6 +8,14 @@ parameters:
     default: mine.send
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_mine.update.yaml
+++ b/packs/salt/actions/local_mine.update.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_mine.update.yaml
+++ b/packs/salt/actions/local_mine.update.yaml
@@ -8,6 +8,14 @@ parameters:
     default: mine.update
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_network.connect.yaml
+++ b/packs/salt/actions/local_network.connect.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_network.connect.yaml
+++ b/packs/salt/actions/local_network.connect.yaml
@@ -8,6 +8,14 @@ parameters:
     default: network.connect
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_network.interface_ip.yaml
+++ b/packs/salt/actions/local_network.interface_ip.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_network.interface_ip.yaml
+++ b/packs/salt/actions/local_network.interface_ip.yaml
@@ -8,6 +8,14 @@ parameters:
     default: network.interface_ip
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_network.ipaddrs.yaml
+++ b/packs/salt/actions/local_network.ipaddrs.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_network.ipaddrs.yaml
+++ b/packs/salt/actions/local_network.ipaddrs.yaml
@@ -8,6 +8,14 @@ parameters:
     default: network.ipaddrs
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_network.ping.yaml
+++ b/packs/salt/actions/local_network.ping.yaml
@@ -8,6 +8,14 @@ parameters:
     default: network.ping
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_network.ping.yaml
+++ b/packs/salt/actions/local_network.ping.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_network.subnets.yaml
+++ b/packs/salt/actions/local_network.subnets.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_network.subnets.yaml
+++ b/packs/salt/actions/local_network.subnets.yaml
@@ -8,6 +8,14 @@ parameters:
     default: network.subnets
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pillar.get.yaml
+++ b/packs/salt/actions/local_pillar.get.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pillar.get.yaml
+++ b/packs/salt/actions/local_pillar.get.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pillar.get
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pip.freeze.yaml
+++ b/packs/salt/actions/local_pip.freeze.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pip.freeze.yaml
+++ b/packs/salt/actions/local_pip.freeze.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pip.freeze
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pip.install.yaml
+++ b/packs/salt/actions/local_pip.install.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pip.install.yaml
+++ b/packs/salt/actions/local_pip.install.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pip.install
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pip.uninstall.yaml
+++ b/packs/salt/actions/local_pip.uninstall.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pip.uninstall
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pip.uninstall.yaml
+++ b/packs/salt/actions/local_pip.uninstall.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pkg.install.yaml
+++ b/packs/salt/actions/local_pkg.install.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pkg.install.yaml
+++ b/packs/salt/actions/local_pkg.install.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pkg.install
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pkg.refresh_db.yaml
+++ b/packs/salt/actions/local_pkg.refresh_db.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pkg.refresh_db.yaml
+++ b/packs/salt/actions/local_pkg.refresh_db.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pkg.refresh_db
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_pkg.remove.yaml
+++ b/packs/salt/actions/local_pkg.remove.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_pkg.remove.yaml
+++ b/packs/salt/actions/local_pkg.remove.yaml
@@ -8,6 +8,14 @@ parameters:
     default: pkg.remove
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.disable.yaml
+++ b/packs/salt/actions/local_puppet.disable.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.disable.yaml
+++ b/packs/salt/actions/local_puppet.disable.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.disable
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.enable.yaml
+++ b/packs/salt/actions/local_puppet.enable.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.enable.yaml
+++ b/packs/salt/actions/local_puppet.enable.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.enable
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.fact.yaml
+++ b/packs/salt/actions/local_puppet.fact.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.fact.yaml
+++ b/packs/salt/actions/local_puppet.fact.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.fact
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.noop.yaml
+++ b/packs/salt/actions/local_puppet.noop.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.noop.yaml
+++ b/packs/salt/actions/local_puppet.noop.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.noop
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.run.yaml
+++ b/packs/salt/actions/local_puppet.run.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.run.yaml
+++ b/packs/salt/actions/local_puppet.run.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.run
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.status.yaml
+++ b/packs/salt/actions/local_puppet.status.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.status.yaml
+++ b/packs/salt/actions/local_puppet.status.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.status
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_puppet.summary.yaml
+++ b/packs/salt/actions/local_puppet.summary.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_puppet.summary.yaml
+++ b/packs/salt/actions/local_puppet.summary.yaml
@@ -8,6 +8,14 @@ parameters:
     default: puppet.summary
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_ret.get_fun.yaml
+++ b/packs/salt/actions/local_ret.get_fun.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_ret.get_fun.yaml
+++ b/packs/salt/actions/local_ret.get_fun.yaml
@@ -8,6 +8,14 @@ parameters:
     default: ret.get_fun
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_ret.get_jid.yaml
+++ b/packs/salt/actions/local_ret.get_jid.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_ret.get_jid.yaml
+++ b/packs/salt/actions/local_ret.get_jid.yaml
@@ -8,6 +8,14 @@ parameters:
     default: ret.get_jid
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_ret.get_jids.yaml
+++ b/packs/salt/actions/local_ret.get_jids.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_ret.get_jids.yaml
+++ b/packs/salt/actions/local_ret.get_jids.yaml
@@ -8,6 +8,14 @@ parameters:
     default: ret.get_jids
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_ret.get_minions.yaml
+++ b/packs/salt/actions/local_ret.get_minions.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_ret.get_minions.yaml
+++ b/packs/salt/actions/local_ret.get_minions.yaml
@@ -8,6 +8,14 @@ parameters:
     default: ret.get_minions
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_all.yaml
+++ b/packs/salt/actions/local_saltutil.sync_all.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_all
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_all.yaml
+++ b/packs/salt/actions/local_saltutil.sync_all.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_grains.yaml
+++ b/packs/salt/actions/local_saltutil.sync_grains.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_grains.yaml
+++ b/packs/salt/actions/local_saltutil.sync_grains.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_grains
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_modules.yaml
+++ b/packs/salt/actions/local_saltutil.sync_modules.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_modules.yaml
+++ b/packs/salt/actions/local_saltutil.sync_modules.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_modules
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_outputters.yaml
+++ b/packs/salt/actions/local_saltutil.sync_outputters.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_outputters
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_outputters.yaml
+++ b/packs/salt/actions/local_saltutil.sync_outputters.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_renderers.yaml
+++ b/packs/salt/actions/local_saltutil.sync_renderers.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_renderers.yaml
+++ b/packs/salt/actions/local_saltutil.sync_renderers.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_renderers
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_returners.yaml
+++ b/packs/salt/actions/local_saltutil.sync_returners.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_returners
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_returners.yaml
+++ b/packs/salt/actions/local_saltutil.sync_returners.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_states.yaml
+++ b/packs/salt/actions/local_saltutil.sync_states.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_states.yaml
+++ b/packs/salt/actions/local_saltutil.sync_states.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_states
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_saltutil.sync_utils.yaml
+++ b/packs/salt/actions/local_saltutil.sync_utils.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_saltutil.sync_utils.yaml
+++ b/packs/salt/actions/local_saltutil.sync_utils.yaml
@@ -8,6 +8,14 @@ parameters:
     default: saltutil.sync_utils
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_schedule.add.yaml
+++ b/packs/salt/actions/local_schedule.add.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_schedule.add.yaml
+++ b/packs/salt/actions/local_schedule.add.yaml
@@ -8,6 +8,14 @@ parameters:
     default: schedule.add
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_schedule.delete.yaml
+++ b/packs/salt/actions/local_schedule.delete.yaml
@@ -8,6 +8,14 @@ parameters:
     default: schedule.delete
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_schedule.delete.yaml
+++ b/packs/salt/actions/local_schedule.delete.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_schedule.disable_job.yaml
+++ b/packs/salt/actions/local_schedule.disable_job.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_schedule.disable_job.yaml
+++ b/packs/salt/actions/local_schedule.disable_job.yaml
@@ -8,6 +8,14 @@ parameters:
     default: schedule.disable_job
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_schedule.enable_job.yaml
+++ b/packs/salt/actions/local_schedule.enable_job.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_schedule.enable_job.yaml
+++ b/packs/salt/actions/local_schedule.enable_job.yaml
@@ -8,6 +8,14 @@ parameters:
     default: schedule.enable_job
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_schedule.run_job.yaml
+++ b/packs/salt/actions/local_schedule.run_job.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_schedule.run_job.yaml
+++ b/packs/salt/actions/local_schedule.run_job.yaml
@@ -8,6 +8,14 @@ parameters:
     default: schedule.run_job
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_service.available.yaml
+++ b/packs/salt/actions/local_service.available.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_service.available.yaml
+++ b/packs/salt/actions/local_service.available.yaml
@@ -8,6 +8,14 @@ parameters:
     default: service.available
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_service.restart.yaml
+++ b/packs/salt/actions/local_service.restart.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_service.restart.yaml
+++ b/packs/salt/actions/local_service.restart.yaml
@@ -8,6 +8,14 @@ parameters:
     default: service.restart
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_service.start.yaml
+++ b/packs/salt/actions/local_service.start.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_service.start.yaml
+++ b/packs/salt/actions/local_service.start.yaml
@@ -8,6 +8,14 @@ parameters:
     default: service.start
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_service.status.yaml
+++ b/packs/salt/actions/local_service.status.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_service.status.yaml
+++ b/packs/salt/actions/local_service.status.yaml
@@ -8,6 +8,14 @@ parameters:
     default: service.status
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_service.stop.yaml
+++ b/packs/salt/actions/local_service.stop.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_service.stop.yaml
+++ b/packs/salt/actions/local_service.stop.yaml
@@ -8,6 +8,14 @@ parameters:
     default: service.stop
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_shadow.del_password.yaml
+++ b/packs/salt/actions/local_shadow.del_password.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_shadow.del_password.yaml
+++ b/packs/salt/actions/local_shadow.del_password.yaml
@@ -8,6 +8,14 @@ parameters:
     default: shadow.del_password
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_shadow.gen_password.yaml
+++ b/packs/salt/actions/local_shadow.gen_password.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_shadow.gen_password.yaml
+++ b/packs/salt/actions/local_shadow.gen_password.yaml
@@ -8,6 +8,14 @@ parameters:
     default: shadow.gen_password
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_shadow.set_expire.yaml
+++ b/packs/salt/actions/local_shadow.set_expire.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_shadow.set_expire.yaml
+++ b/packs/salt/actions/local_shadow.set_expire.yaml
@@ -8,6 +8,14 @@ parameters:
     default: shadow.set_expire
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_state.highstate.yaml
+++ b/packs/salt/actions/local_state.highstate.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_state.highstate.yaml
+++ b/packs/salt/actions/local_state.highstate.yaml
@@ -8,6 +8,14 @@ parameters:
     default: state.highstate
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_state.single.yaml
+++ b/packs/salt/actions/local_state.single.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_state.single.yaml
+++ b/packs/salt/actions/local_state.single.yaml
@@ -8,6 +8,14 @@ parameters:
     default: state.single
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_state.sls.yaml
+++ b/packs/salt/actions/local_state.sls.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_state.sls.yaml
+++ b/packs/salt/actions/local_state.sls.yaml
@@ -8,6 +8,14 @@ parameters:
     default: state.sls
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.add.yaml
+++ b/packs/salt/actions/local_supervisord.add.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.add.yaml
+++ b/packs/salt/actions/local_supervisord.add.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.add
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.custom.yaml
+++ b/packs/salt/actions/local_supervisord.custom.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.custom.yaml
+++ b/packs/salt/actions/local_supervisord.custom.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.custom
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.remove.yaml
+++ b/packs/salt/actions/local_supervisord.remove.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.remove.yaml
+++ b/packs/salt/actions/local_supervisord.remove.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.remove
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.reread.yaml
+++ b/packs/salt/actions/local_supervisord.reread.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.reread.yaml
+++ b/packs/salt/actions/local_supervisord.reread.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.reread
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.restart.yaml
+++ b/packs/salt/actions/local_supervisord.restart.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.restart.yaml
+++ b/packs/salt/actions/local_supervisord.restart.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.restart
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.start.yaml
+++ b/packs/salt/actions/local_supervisord.start.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.start
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_supervisord.start.yaml
+++ b/packs/salt/actions/local_supervisord.start.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.stop.yaml
+++ b/packs/salt/actions/local_supervisord.stop.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_supervisord.stop.yaml
+++ b/packs/salt/actions/local_supervisord.stop.yaml
@@ -8,6 +8,14 @@ parameters:
     default: supervisord.stop
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.available.yaml
+++ b/packs/salt/actions/local_systemd.available.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.available.yaml
+++ b/packs/salt/actions/local_systemd.available.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.available
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.disable.yaml
+++ b/packs/salt/actions/local_systemd.disable.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.disable.yaml
+++ b/packs/salt/actions/local_systemd.disable.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.disable
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.enable.yaml
+++ b/packs/salt/actions/local_systemd.enable.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.enable.yaml
+++ b/packs/salt/actions/local_systemd.enable.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.enable
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.restart.yaml
+++ b/packs/salt/actions/local_systemd.restart.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.restart.yaml
+++ b/packs/salt/actions/local_systemd.restart.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.restart
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.start.yaml
+++ b/packs/salt/actions/local_systemd.start.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.start.yaml
+++ b/packs/salt/actions/local_systemd.start.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.start
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.stop.yaml
+++ b/packs/salt/actions/local_systemd.stop.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.stop.yaml
+++ b/packs/salt/actions/local_systemd.stop.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.stop
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_systemd.systemctl_reload.yaml
+++ b/packs/salt/actions/local_systemd.systemctl_reload.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_systemd.systemctl_reload.yaml
+++ b/packs/salt/actions/local_systemd.systemctl_reload.yaml
@@ -8,6 +8,14 @@ parameters:
     default: systemd.systemctl_reload
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_test.cross_test.yaml
+++ b/packs/salt/actions/local_test.cross_test.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_test.cross_test.yaml
+++ b/packs/salt/actions/local_test.cross_test.yaml
@@ -8,6 +8,14 @@ parameters:
     default: test.cross_test
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_test.echo.yaml
+++ b/packs/salt/actions/local_test.echo.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_test.echo.yaml
+++ b/packs/salt/actions/local_test.echo.yaml
@@ -8,6 +8,14 @@ parameters:
     default: test.echo
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_test.ping.yaml
+++ b/packs/salt/actions/local_test.ping.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_test.ping.yaml
+++ b/packs/salt/actions/local_test.ping.yaml
@@ -8,6 +8,14 @@ parameters:
     default: test.ping
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_useradd.add.yaml
+++ b/packs/salt/actions/local_useradd.add.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_useradd.add.yaml
+++ b/packs/salt/actions/local_useradd.add.yaml
@@ -8,6 +8,14 @@ parameters:
     default: useradd.add
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_useradd.chshell.yaml
+++ b/packs/salt/actions/local_useradd.chshell.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/actions/local_useradd.chshell.yaml
+++ b/packs/salt/actions/local_useradd.chshell.yaml
@@ -8,6 +8,14 @@ parameters:
     default: useradd.chshell
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_useradd.delete.yaml
+++ b/packs/salt/actions/local_useradd.delete.yaml
@@ -8,6 +8,14 @@ parameters:
     default: useradd.delete
     immutable: true
     type: string
+  target:
+     required: false
+     type: string
+     default: *
+  expr_form:
+    required: false
+    type: string
+    default: glob
   args:
     required: false
     type: array

--- a/packs/salt/actions/local_useradd.delete.yaml
+++ b/packs/salt/actions/local_useradd.delete.yaml
@@ -11,7 +11,7 @@ parameters:
   target:
      required: false
      type: string
-     default: *
+     default: '*'
   expr_form:
     required: false
     type: string

--- a/packs/salt/pack.yaml
+++ b/packs/salt/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version : 0.4.1
+version : 0.4.2
 author : jcockhren
 email : jurnell@sophicware.com


### PR DESCRIPTION
## Salt Pack

### Status 

- bugfix

### Description

This bugfix ensures the developer can customize which minons are targeted and how when using [Execution Module Actions](https://github.com/StackStorm/st2contrib/tree/master/packs/salt#execution-module-actions)

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)