### PR TITLE
Correct a typo in Duo pack auth_auth alias

### DIFF
--- a/packs/duo/aliases/auth_auth.yaml
+++ b/packs/duo/aliases/auth_auth.yaml
@@ -8,7 +8,7 @@ formats:
 ack:
   enabled: true
   append_url: false
-  format: "Spending a Duo push request..."
+  format: "Sending a Duo push request..."
 result:
   format: |
     {% if execution.status == 'succeeded' %}

--- a/packs/duo/pack.yaml
+++ b/packs/duo/pack.yaml
@@ -4,6 +4,6 @@ description: Use Duo 2FA authenication with StackStorm actions.
 keywords:
     - 2Fa
     - Duo
-version: 0.1
+version: 0.2
 author: Jon Middleton
 email: jon.middleton@pulsant.com


### PR DESCRIPTION
## Duo

### Status 

- bugfix

### Description

Correct a type (_sending_, not _spending_) in Duo pack auth_auth alias.

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [X] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] Tests (not required but really recommended)
