### PR TITLE
MSSQL shouldn't fail when result has no data

### DIFF
--- a/packs/mssql/actions/lib/results_processor.py
+++ b/packs/mssql/actions/lib/results_processor.py
@@ -2,7 +2,6 @@ import _mssql
 from tempfile import NamedTemporaryFile
 import csv
 import os
-import sys
 
 __all__ = [
     'ResultsProcessor'
@@ -16,28 +15,20 @@ class ResultsProcessor(object):
     Utility for processing action response, e.g. changing returned results or passing data via disk
     """
 
-    NO_DATA = 2
-
-    def __init__(self, config, logger):
+    def __init__(self, config):
         self.config = config
-        self.logger = logger
 
     def execute_scalar(self, response, cursor):
         """
         Returns the scalar response.
         """
-        if not response:
-            sys.exit(self.NO_DATA)
         return response
 
     def execute_row(self, response, cursor):
         """
         Returns a mapping of column name to value for a row.
         """
-        row = self._filter_numbered_columns(response or {})
-        if not row:
-            sys.exit(self.NO_DATA)
-        return row
+        return self._filter_numbered_columns(response or {})
 
     def execute_insert(self, response, cursor):
         """
@@ -49,8 +40,6 @@ class ResultsProcessor(object):
         """
         Returns the number of rows affected by the non-query.
         """
-        if cursor.rows_affected == 0:
-            sys.exit(self.NO_DATA)
         return cursor.rows_affected
 
     def execute_query(self, response, cursor):
@@ -86,9 +75,6 @@ class ResultsProcessor(object):
                 writer.writerow(first_row)
                 for row in cursor:
                     writer.writerow(self._filter_numbered_columns(row))
-        if not output_files:
-            self.logger.info("Query returned no results, failing")
-            sys.exit(self.NO_DATA)
         return {"output_files": output_files}
 
     def _filter_numbered_columns(self, row):

--- a/packs/mssql/actions/mssql_runner.py
+++ b/packs/mssql/actions/mssql_runner.py
@@ -21,7 +21,7 @@ class MSSQLRunner(MSSQLAction):
 
     def __init__(self, config):
         super(MSSQLRunner, self).__init__(config)
-        self.processor = ResultsProcessor(self.config, self.logger)
+        self.processor = ResultsProcessor(self.config)
 
     def run(self, action, query_string, params=None,
             database=None, server=None, user=None, password=None):

--- a/packs/mssql/actions/workflows/execute.query_and_email.yaml
+++ b/packs/mssql/actions/workflows/execute.query_and_email.yaml
@@ -15,6 +15,6 @@ chain:
       to: '{{email_to}}'
       from: '{{email_from}}'
       subject: '{{email_subject}}'
-      body: '{% if query_mssql.result.output_files | length > 0 %}{{email_body}}{% endif %}'
       attachments: '{{query_mssql.result.output_files | join(",")}}'
+      body: '{% if query_mssql.result.output_files | length > 0 %}{{email_body}}{% endif %}'
       send_empty_body: False

--- a/packs/mssql/actions/workflows/execute.query_and_email.yaml
+++ b/packs/mssql/actions/workflows/execute.query_and_email.yaml
@@ -7,24 +7,14 @@ chain:
       query_string: '{{query_string}}'
       params: '{{params}}'
       database: '{{database}}'
-    on-success: 'check_for_results'
-  -
-    name: 'check_for_results'
-    ref: 'core.local'
-    parameters:
-      cmd: '[[ "{{query_mssql.result.output_files | length}}" -gt 0 ]]'
     on-success: 'email_results'
-    on-failure: 'success_on_no_data'
   -
     name: 'email_results'
     ref: 'core.sendmail'
     parameters:
+      send_empty_body: False
       attachments: '{{query_mssql.result.output_files | join(",")}}'
       subject: '{{email_subject}}'
-      body: '{{email_body}}'
+      body: '{% if query_mssql.result.output_files | length > 0 %}{{email_body}}{% endif %}'
       from: '{{email_from}}'
       to: '{{email_to}}'
-  -
-    name: 'success_on_no_data'
-    # so the parent action shows "SUCCESSFUL" if NO DATA
-    ref: 'core.noop'

--- a/packs/mssql/actions/workflows/execute.query_and_email.yaml
+++ b/packs/mssql/actions/workflows/execute.query_and_email.yaml
@@ -7,9 +7,13 @@ chain:
       query_string: '{{query_string}}'
       params: '{{params}}'
       database: '{{database}}'
-    # success indicates returned data. don't email if NO DATA
+    on-success: 'check_for_results'
+  -
+    name: 'check_for_results'
+    ref: 'core.local'
+    parameters:
+      cmd: '[[ "{{query_mssql.result.output_files | length}}" -gt 0 ]]'
     on-success: 'email_results'
-    # failure may indicate no data or an actual error
     on-failure: 'success_on_no_data'
   -
     name: 'email_results'
@@ -23,7 +27,4 @@ chain:
   -
     name: 'success_on_no_data'
     # so the parent action shows "SUCCESSFUL" if NO DATA
-    ref: 'core.local'
-    parameters:
-      # mssql.execute.query returns 1 on ERROR and 2 if NO DATA
-      cmd: '[[ "{{query_mssql.exit_code}}" -eq 2 ]]'
+    ref: 'core.noop'

--- a/packs/mssql/actions/workflows/execute.query_and_email.yaml
+++ b/packs/mssql/actions/workflows/execute.query_and_email.yaml
@@ -12,9 +12,9 @@ chain:
     name: 'email_results'
     ref: 'core.sendmail'
     parameters:
-      send_empty_body: False
-      attachments: '{{query_mssql.result.output_files | join(",")}}'
+      to: '{{email_to}}'
+      from: '{{email_from}}'
       subject: '{{email_subject}}'
       body: '{% if query_mssql.result.output_files | length > 0 %}{{email_body}}{% endif %}'
-      from: '{{email_from}}'
-      to: '{{email_to}}'
+      attachments: '{{query_mssql.result.output_files | join(",")}}'
+      send_empty_body: False


### PR DESCRIPTION
## MSSQL Pack

### Status 

- pack update, complete

### Description

Updating the MSSQL as per feedback from the original [PR](https://github.com/StackStorm/st2contrib/pull/448). Namely, don't exit with status `2` when there's no data. Exit normally (successfully) and let the workflow check for data if necessary.

### Checklist (tick everything that applies)

- [X] Metadata: pack.yaml, icon, structure (required for new packs)
- [ ] Version bump (required for changed packs)
- [X] Code linting (required, can be done after the PR checks)
- [X] Tests (not required but really recommended)