### PR TITLE
Duo announcement

### DIFF
--- a/packs/duo/actions/announce_success.yaml
+++ b/packs/duo/actions/announce_success.yaml
@@ -13,3 +13,4 @@ parameters:
   uuid:
     type: "string"
     description: "UUID of a frozen action."
+    required: true

--- a/packs/duo/pack.yaml
+++ b/packs/duo/pack.yaml
@@ -4,6 +4,6 @@ description: Use Duo 2FA authenication with StackStorm actions.
 keywords:
     - 2Fa
     - Duo
-version: 0.2
+version: 0.2.1
 author: Jon Middleton
 email: jon.middleton@pulsant.com


### PR DESCRIPTION
Makes UUID required in the announcement for Hubot two-factor auth. Not really necessary, since it’s never called without an UUID (nor would it have any effect), but that’s how it should be.