### PR TITLE
Fix git-changes scripts - ignore deleted files

### DIFF
--- a/scripts/utils/git-changes-directories
+++ b/scripts/utils/git-changes-directories
@@ -3,4 +3,5 @@ ROOT_DIRECTORY=$1
 BASE_BRANCH="origin/master"
 
 cd ${ROOT_DIRECTORY}
-echo $(git diff --name-only ${BASE_BRANCH} | xargs -I FILENAME dirname FILENAME | awk '/^\./ {next} /.*/{print "./"$1}')
+# Note: We include all but deleted files ("D" flag)
+echo $(git diff --diff-filter=ACMRTUXB --name-only ${BASE_BRANCH} | xargs -I FILENAME dirname FILENAME | awk '/^\./ {next} /.*/{print "./"$1}')

--- a/scripts/utils/git-changes-files
+++ b/scripts/utils/git-changes-files
@@ -3,4 +3,5 @@ ROOT_DIRECTORY=$1
 BASE_BRANCH="origin/master"
 
 cd ${ROOT_DIRECTORY}
-echo $(git diff --name-only ${BASE_BRANCH})
+# Note: We include all but deleted files ("D" flag)
+echo $(git diff --diff-filter=ACMRTUXB --name-only ${BASE_BRANCH})

--- a/scripts/utils/git-changes-json
+++ b/scripts/utils/git-changes-json
@@ -15,4 +15,5 @@ if [ ! -z "${FORCE_CHECK_PACK}" ] && [ "${FORCE_CHECK_PACK}" != "false" ]; then
 fi
 
 cd ${ROOT_DIRECTORY}
-echo $(git diff --name-only ${BASE_BRANCH} -- '*.json')
+# Note: We include all but deleted files ("D" flag)
+echo $(git diff --diff-filter=ACMRTUXB --name-only ${BASE_BRANCH} -- '*.json')

--- a/scripts/utils/git-changes-packs
+++ b/scripts/utils/git-changes-packs
@@ -15,4 +15,5 @@ if [ ! -z "${FORCE_CHECK_PACK}" ] && [ "${FORCE_CHECK_PACK}" != "false" ]; then
 fi
 
 cd ${ROOT_DIRECTORY}
-echo $(git diff --name-only ${BASE_BRANCH} -- 'packs/*' | xargs -I FILENAME dirname FILENAME | awk -F'/' '/^\./ {next} /^[^\/]+$/ {next} /^scripts/ {next} /.*/{print $1"/"$2"/"}' | uniq) 
+# Note: We include all but deleted files ("D" flag)
+echo $(git diff --diff-filter=ACMRTUXB --name-only ${BASE_BRANCH} -- 'packs/*' | xargs -I FILENAME dirname FILENAME | awk -F'/' '/^\./ {next} /^[^\/]+$/ {next} /^scripts/ {next} /.*/{print $1"/"$2"/"}' | uniq)

--- a/scripts/utils/git-changes-py
+++ b/scripts/utils/git-changes-py
@@ -15,4 +15,5 @@ if [ ! -z "${FORCE_CHECK_PACK}" ] && [ "${FORCE_CHECK_PACK}" != "false" ]; then
 fi
 
 cd ${ROOT_DIRECTORY}
-echo $(git diff --name-only ${BASE_BRANCH} -- '*.py')
+# Note: We include all but deleted files ("D" flag)
+echo $(git diff --diff-filter=ACMRTUXB --name-only ${BASE_BRANCH} -- '*.py')

--- a/scripts/utils/git-changes-yaml
+++ b/scripts/utils/git-changes-yaml
@@ -15,4 +15,5 @@ if [ ! -z "${FORCE_CHECK_PACK}" ] && [ "${FORCE_CHECK_PACK}" != "false" ]; then
 fi
 
 cd ${ROOT_DIRECTORY}
-echo $(git diff --name-only ${BASE_BRANCH} -- '*.yaml' '*.yml')
+# Note: We include all but deleted files ("D" flag)
+echo $(git diff --diff-filter=ACMRTUXB --name-only ${BASE_BRANCH} -- '*.yaml' '*.yml')


### PR DESCRIPTION
This pull request updates `git-changes-*` scripts to ignore deleted files.

Previously deleted files were also includes which means lint and other steps would fail if a file or directory was deleted (e.g. https://travis-ci.org/StackStorm/st2contrib/jobs/120922066).

This issue affects #462 and was originally reported by @paul-mulvihill on Slack and I finally get a chance to dig in.