### PR TITLE
Fix run.py to not assume tokens is present in the args

### DIFF
--- a/packs/slack/actions/api.test.yaml
+++ b/packs/slack/actions/api.test.yaml
@@ -13,7 +13,4 @@ parameters:
   foo:
     required: false
     type: string
-  token:
-    required: false
-    type: string
 runner_type: run-python

--- a/packs/slack/actions/run.py
+++ b/packs/slack/actions/run.py
@@ -10,7 +10,7 @@ BASE_URL = 'https://slack.com/api/'
 class SlackAction(Action):
 
     def run(self, **kwargs):
-        if kwargs['token'] is None:
+        if kwargs.get('token', None) is None:
             kwargs['token'] = self.config['action_token']
 
         return self._get_request(kwargs)


### PR DESCRIPTION
## slack

### Status 

Updates to work with auto generated code.