### PR TITLE
Account for type error in kwargs.get('args')

### DIFF
--- a/packs/salt/actions/lib/base.py
+++ b/packs/salt/actions/lib/base.py
@@ -54,7 +54,7 @@ class SaltAction(Action):
         if client is 'local':
             self.data['tgt'] = kwargs.get('target', '*')
             self.data['expr_form'] = kwargs.get('expr_form', 'glob')
-        if len(kwargs.get('args', [])) > 0:
+        if isinstance(kwargs.get('args', []), list) and len(kwargs.get('args', [])) > 0:
             self.data['arg'] = kwargs['args']
         if len(kwargs.get('data', {})) > 0:
             if kwargs['data'].get('kwargs', None) is not None:

--- a/packs/salt/actions/local.yaml
+++ b/packs/salt/actions/local.yaml
@@ -23,6 +23,7 @@ parameters:
         description: 'Positional arguments to pass to the module'
         type: array
         required: false
+        default: []
     kwargs:
         description: 'Key Pair arguments to pass to the module'
         type: object

--- a/packs/salt/pack.yaml
+++ b/packs/salt/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - salt
   - cfg management
   - configuration management
-version : 0.4.3
+version : 0.4.4
 author : jcockhren
 email : jurnell@sophicware.com


### PR DESCRIPTION
## Saltstack Pack (replace this with the pack's name)

### Status 
- bugfix

### Description
Minor Bugfix lets test.ping run, as the saltstack module requires no arguments passed to it. 

### Checklist (tick everything that applies)
- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [ ] Version bump (required for changed packs)
- [X ] Code linting (required, can be done after the PR checks)
- [X] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)

Fixes 
```
 st2 run salt.local module=test.ping
.
id: 57192d485681755ce9698f3a
status: failed
parameters:
  module: test.ping
result:
  exit_code: 1
  result: null
  stderr: "Traceback (most recent call last):
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/python_action_wrapper.py", line 164, in <module>
    obj.run()
  File "/opt/stackstorm/st2/local/lib/python2.7/site-packages/st2actions/runners/python_action_wrapper.py", line 103, in run
    output = action.run(**self._parameters)
  File "/opt/stackstorm/packs/salt/actions/local.py", line 35, in run
    data=kwargs)
  File "/opt/stackstorm/packs/salt/actions/lib/base.py", line 57, in generate_package
    if len(kwargs.get('args', [])) > 0:
TypeError: object of type 'NoneType' has no len()
"
  stdout: ''
````