### PR TITLE
Update orion.node_status to use color for alias results reflecting node stats

### DIFF
--- a/packs/orion/CHANGES.md
+++ b/packs/orion/CHANGES.md
@@ -1,6 +1,11 @@
 # Changelog
 
-# In Development
+# 0.3.1
+
+- In the Orion.node_status alais set the color for the result so it
+  reflects it status.
+
+# 0.3
 
 - Added the following actions:
    - node_create (tbc).

--- a/packs/orion/README.md
+++ b/packs/orion/README.md
@@ -13,6 +13,12 @@ orion:
     password: S0meth1ngSt0ng?
 ```
 
+## StackStorm Version
+
+This pack uses features released in 1.4+, if your using on an older
+release some changes will be likley (at least removal of the `extra`
+sections in some aliases.
+
 ## Actions
 
 ### tbc

--- a/packs/orion/aliases/node_status.yaml
+++ b/packs/orion/aliases/node_status.yaml
@@ -10,11 +10,13 @@ formats:
 ack:
   enabled: false
   append_url: false
-  format: "Let me check {{execution.parameters.node}} on {{execution.parameters.node}} Orion Platform for you..."
+  format: "Let me check {{execution.parameters.node}} on {{execution.parameters.platform}} Orion Platform for you..."
 result:
+  extra:
+    color: "{{execution.result.result.color|default('#439FE0')}}"
   format: |
     {% if execution.status == 'succeeded' %}
-    {{ execution.parameters.node }} is {{ execution.result.result.status }}{~}
+    {{ execution.parameters.node }} is {{ execution.result.result.status }}
     {% else %}
     Error: {{execution.result.stdout}}{~}See {{execution.id}} for more details.
     {% endif %}

--- a/packs/orion/pack.yaml
+++ b/packs/orion/pack.yaml
@@ -6,6 +6,6 @@ keywords:
    - orion
    - ncm
    - npm
-version: 0.3
+version: 0.3.1
 author: Jon Middleton
 email: jon.middleton@pulsant.com


### PR DESCRIPTION
## Orion

### Status 

- pack extension, complete.

### Description

Use the color reflecting a node status that was already in the results and use the extra color support from 1.4 in the orion.node_status alias results.

### Checklist (tick everything that applies)

- [X] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [X] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)