### PR TITLE
Hpe icsp fix

### DIFF
--- a/packs/hpe-icsp/actions/icsp_server_attribute_set.py
+++ b/packs/hpe-icsp/actions/icsp_server_attribute_set.py
@@ -34,6 +34,7 @@ class SetServerAttribute(ICSPBaseActions):
         # any attribute to replace must be defined in full in the new call
 
         currentdetails = self.icsp_get(endpoint)
+        payload["name"] = currentdetails['name']
         for element in currentdetails['customAttributes']:
             if element['values'][0]['scope'] == 'server'\
                     and not element['key'].startswith("__"):

--- a/packs/hpe-icsp/actions/workflows/icsp_multi_server_attribute_add.yaml
+++ b/packs/hpe-icsp/actions/workflows/icsp_multi_server_attribute_add.yaml
@@ -24,7 +24,7 @@ workflows:
         with-items:
           - id in <% $.identifiers %>
           - value in <% $.attribute_values %>
-        workflow: hpe-icsp.icsp_server_attributes_ms_set.single_run
+        workflow: hpe-icsp.icsp_multi_server_attribute_add.single_run
         input:
           identifier: <% $.id %>
           id_type: <% $.id_type %>

--- a/packs/hpe-icsp/pack.yaml
+++ b/packs/hpe-icsp/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : hpe-icsp
 description : Pack for HP Enterprise Insight Control Server Provisioning Integration
-version : 0.1
+version : 0.2
 author : Paul Mulvihill
 email : paul.mulvihill@pulsant.com


### PR DESCRIPTION
## HPE-ICSP
### Status

- bugfix

### Description

Corrected typo in "icsp_multi_server_attribute_add.yaml" work flow for inner flow name.
Addition of "name" in attribute set api call otherwise Display name becomes blank which causes build plans to later fail.

### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
