### PR TITLE
Remove sudo parameter from all the local runner actions

### DIFF
--- a/packs/sensu/actions/aggregate_check.yaml
+++ b/packs/sensu/actions/aggregate_check.yaml
@@ -12,7 +12,5 @@ parameters:
   age:
     type: string
     description: The number of seconds old an aggregate must be to be listed.
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/aggregate_check_delete.yaml
+++ b/packs/sensu/actions/aggregate_check_delete.yaml
@@ -14,7 +14,5 @@ parameters:
     description: ''
     default: 'yes'
     immutable: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/aggregate_check_issued.yaml
+++ b/packs/sensu/actions/aggregate_check_issued.yaml
@@ -15,7 +15,5 @@ parameters:
   results:
     type: string
     description: Return the raw result data
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/aggregate_list.yaml
+++ b/packs/sensu/actions/aggregate_list.yaml
@@ -8,12 +8,10 @@ parameters:
   limit:
     type: string
     description: The number of aggregates to return.
-    default: 
+    default:
   offset:
     type: string
     description: The number of aggregates to offset before returning items.
-    default: 
-  sudo:
-    immutable: true
+    default:
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/check.yaml
+++ b/packs/sensu/actions/check.yaml
@@ -9,7 +9,5 @@ parameters:
     type: string
     description: The check name
     required: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/check_list.yaml
+++ b/packs/sensu/actions/check_list.yaml
@@ -5,7 +5,5 @@ description: List Sensu checks
 enabled: true
 entry_point: checks.py
 parameters:
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/client.yaml
+++ b/packs/sensu/actions/client.yaml
@@ -9,7 +9,5 @@ parameters:
     type: string
     description: The client name
     required: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/client_delete.yaml
+++ b/packs/sensu/actions/client_delete.yaml
@@ -14,7 +14,5 @@ parameters:
     description: ''
     default: 'yes'
     immutable: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/client_history.yaml
+++ b/packs/sensu/actions/client_history.yaml
@@ -14,7 +14,5 @@ parameters:
     description: ''
     default: 'yes'
     immutable: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/client_list.yaml
+++ b/packs/sensu/actions/client_list.yaml
@@ -8,12 +8,10 @@ parameters:
   limit:
     type: string
     description: The number of clients to return.
-    default: 
+    default:
   offset:
     type: string
     description: The number of clients to offset before returning items.
-    default: 
-  sudo:
-    immutable: true
+    default:
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/event.yaml
+++ b/packs/sensu/actions/event.yaml
@@ -13,7 +13,5 @@ parameters:
     type: string
     description: The check to get information on
     required: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/event_delete.yaml
+++ b/packs/sensu/actions/event_delete.yaml
@@ -17,7 +17,5 @@ parameters:
     description: ''
     default: 'yes'
     immutable: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/event_list.yaml
+++ b/packs/sensu/actions/event_list.yaml
@@ -5,7 +5,5 @@ description: List Sensu events
 enabled: true
 entry_point: events.py
 parameters:
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/event_list_client.yaml
+++ b/packs/sensu/actions/event_list_client.yaml
@@ -9,7 +9,5 @@ parameters:
     type: string
     description: The client name
     required: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/event_resolve.yaml
+++ b/packs/sensu/actions/event_resolve.yaml
@@ -9,7 +9,5 @@ parameters:
     type: string
     description: The client name
     required: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/health.yaml
+++ b/packs/sensu/actions/health.yaml
@@ -14,7 +14,5 @@ parameters:
     description: The maximum number of transport queued messages to be considered
       healthy.
     default: '100'
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/info.yaml
+++ b/packs/sensu/actions/info.yaml
@@ -5,7 +5,5 @@ description: Sensu System Info
 enabled: true
 entry_point: info.py
 parameters:
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/silence.yaml
+++ b/packs/sensu/actions/silence.yaml
@@ -18,7 +18,5 @@ parameters:
   message:
     type: string
     description: Message to post with the silence stash.
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true

--- a/packs/sensu/actions/unsilence.yaml
+++ b/packs/sensu/actions/unsilence.yaml
@@ -12,7 +12,5 @@ parameters:
     type: string
     description: The client to unsilence.
     required: true
-  sudo:
-    immutable: true
   kwarg_op:
     immutable: true


### PR DESCRIPTION
This pull request sudo parameter from all the local runner actions to account for this runner parameter removal in https://github.com/StackStorm/st2/pull/2671.

Note: those changes are fully backward compatible so we can merge them before we merge https://github.com/StackStorm/st2/pull/2671.
