### PR TITLE
Add pack-missing-tests script to make it easy to spot missing pack tests.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -83,6 +83,14 @@ packs-tests: requirements .clone_st2_repo .packs-tests
 	@echo
 	. $(VIRTUALENV_DIR)/bin/activate; if [ ! "${CHANGED_PACKS}" ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then $(ST2_REPO_PATH)/st2common/bin/st2-run-pack-tests -x -p $$pack || exit 1 ; fi; done
 
+.PHONY: packs-missing-tests
+packs-missing-tests:
+	@echo
+	@echo "==================== pack-missing-tests ===================="
+	@echo
+	if [ ! "${CHANGED_PACKS}" ]; then echo No packs have changed, skipping run...; fi; for pack in $(CHANGED_PACKS); do if [ -n "$$pack" ]; then scripts/pack-missing-tests.sh $$pack || exit 1 ; fi; done
+
+
 .PHONY: .clone_st2_repo
 .clone_st2_repo:
 	@echo

--- a/scripts/pack-missing-tests.sh
+++ b/scripts/pack-missing-tests.sh
@@ -27,7 +27,7 @@ fi
 
 MISSING_COUNT=0
 
-echo "Actions missing tests:"
+echo "Python Actions missing tests:"
 for ACTION in ${ACTIONS}; do 
     if [ ! -f  ${PACK}/tests/test_action_${ACTION} ]; then
 	echo -e "\t${ACTION}"
@@ -36,7 +36,7 @@ for ACTION in ${ACTIONS}; do
 done
 
 echo 
-echo "Tests with no actions:"
+echo "Python Tests with no actions:"
 for TEST in ${ACTION_TESTS}; do 
     if [ ! -f ${PACK}/actions/${TEST#test_action_} ]; then
 	echo -e "\t$TEST"
@@ -44,5 +44,5 @@ for TEST in ${ACTION_TESTS}; do
 done
 
 echo
-echo -e "Coverage:"
+echo -e "Python Test Coverage:"
 echo -e "\tActions: ${ACTION_TEST_COUNT}/${ACTION_COUNT}"

--- a/scripts/pack-missing-tests.sh
+++ b/scripts/pack-missing-tests.sh
@@ -1,0 +1,42 @@
+#!/bin/bash
+
+if [ -n "${1}" ]; then
+    DIR=${1}
+else
+    echo "Need a pack dir"
+    exit 1
+fi
+
+ACTIONS=$(cd ${DIR}/actions;ls -1 *.py)
+ACTION_COUNT=$(ls -1 ${DIR}/actions/*.py | wc -l)
+
+ACTION_TESTS=$(cd ${DIR}/tests;ls -1 *.py)
+if [ -d ${DIR}/tests/ ]; then
+    ACTION_TEST_COUNT=$(ls -1 ${DIR}/tests/test_action_*.py | wc -l)
+else
+    ACTION_TEST_COUNT=0
+fi
+
+MISSING_COUNT=0
+
+echo "Missing tests for these actions:"
+for ACTION in ${ACTIONS}; do 
+    if [ ! -f  ${DIR}/tests/test_action_${ACTION} ]; then 
+	echo -e "\t${ACTION}"
+	MISSING_COUNT=$((MISSING_COUNT+1))
+    fi
+done
+
+echo 
+echo "Tests with no actions:"
+for TEST in ${ACTION_TESTS}; do 
+    if [ ! -f ${DIR}/actions/${TEST#test_action_} ]; then
+	echo -e "\t$TEST"
+    fi
+done
+
+echo
+echo "Total missing tests: ${MISSING_COUNT}"
+
+echo
+echo "Stats: ${ACTION_TEST_COUNT} test for ${ACTION_COUNT} actions"

--- a/scripts/pack-missing-tests.sh
+++ b/scripts/pack-missing-tests.sh
@@ -1,27 +1,35 @@
 #!/bin/bash
 
 if [ -n "${1}" ]; then
-    DIR=${1}
+    PACK=${1}
 else
-    echo "Need a pack dir"
+    echo "Need a pack "
     exit 1
 fi
 
-ACTIONS=$(cd ${DIR}/actions;ls -1 *.py)
-ACTION_COUNT=$(ls -1 ${DIR}/actions/*.py | wc -l)
+echo -e "====== ${PACK} ======\n"
 
-ACTION_TESTS=$(cd ${DIR}/tests;ls -1 *.py)
-if [ -d ${DIR}/tests/ ]; then
-    ACTION_TEST_COUNT=$(ls -1 ${DIR}/tests/test_action_*.py | wc -l)
+if [ -d ${PACK}/actions ]; then
+    ACTIONS=$(cd ${PACK}/actions;ls -1 *.py)
+    ACTION_COUNT=$(ls -1 ${PACK}/actions/*.py | wc -l)
+else
+    ACTIONS=""
+    ACTION_COUNT=0
+fi
+
+if [ -d ${PACK}/tests/ ]; then
+    ACTION_TESTS=$(cd ${PACK}/tests;ls -1 test_action_*.py)
+    ACTION_TEST_COUNT=$(ls -1 ${PACK}/tests/test_action_*.py | wc -l)
 else
     ACTION_TEST_COUNT=0
+    ACTION_TESTS=""
 fi
 
 MISSING_COUNT=0
 
-echo "Missing tests for these actions:"
+echo "Actions missing tests:"
 for ACTION in ${ACTIONS}; do 
-    if [ ! -f  ${DIR}/tests/test_action_${ACTION} ]; then 
+    if [ ! -f  ${PACK}/tests/test_action_${ACTION} ]; then
 	echo -e "\t${ACTION}"
 	MISSING_COUNT=$((MISSING_COUNT+1))
     fi
@@ -30,13 +38,11 @@ done
 echo 
 echo "Tests with no actions:"
 for TEST in ${ACTION_TESTS}; do 
-    if [ ! -f ${DIR}/actions/${TEST#test_action_} ]; then
+    if [ ! -f ${PACK}/actions/${TEST#test_action_} ]; then
 	echo -e "\t$TEST"
     fi
 done
 
 echo
-echo "Total missing tests: ${MISSING_COUNT}"
-
-echo
-echo "Stats: ${ACTION_TEST_COUNT} test for ${ACTION_COUNT} actions"
+echo -e "Coverage:"
+echo -e "\tActions: ${ACTION_TEST_COUNT}/${ACTION_COUNT}"


### PR DESCRIPTION
## Add pack-missing-tests script

### Status 

Functional - Request for comment

### Description

Adds a script that makes it easy to spot missing or extra tests for packs that have changed..

### Checklist (tick everything that applies)

- [x] Code linting (required, can be done after the PR checks)
