### PR TITLE
hpe-icsp refinement

### DIFF
--- a/packs/hpe-icsp/README.md
+++ b/packs/hpe-icsp/README.md
@@ -38,5 +38,6 @@ To increase the version number to a later release will require updates to action
 * `hpe-icsp.icsp_job_status` - Retrieve Status of specified Job
 * `hpe-icsp.icsp_mid_get` - Retrieve ICSP ID (MID) for Specified Server
 * `hpe-icsp.icsp_server_delete` - Remove server record from ICSP instance
+* `hpe-icsp.icsp_server_details_get` - Return Summary information on server
 * `hpe-icsp.icsp_ca_cert` - Retrieve certificate for ICSP server
 * `hpe-icsp.icsp_id_to_os` - Allow for the application of build plans to a single UUID or Serial number.

--- a/packs/hpe-icsp/README.md
+++ b/packs/hpe-icsp/README.md
@@ -30,14 +30,16 @@ To increase the version number to a later release will require updates to action
 
 ## Actions
 
-* `hpe-icsp.icsp_server_attributes_get` - Retrieve attributes set against server
-* `hpe-icsp.icsp_server_attributes_set` - Assign custom cttributes to server
-* `hpe-icsp.icsp_server_data_format` - Generates the json object used in the buildplan apply action
 * `hpe-icsp.icsp_buildplan_apply` - Assign build plans provided against list of servers
 * `hpe-icsp.icsp_buildplan_get` - Retrieve list of Build plans and Build Plan URIs
+* `hpe-icsp.icsp_ca_cert` - Retrieve certificate for ICSP server
+* `hpe-icsp.icsp_ids_to_os` - Allow for the application of build plans to a list of Servers
 * `hpe-icsp.icsp_job_status` - Retrieve Status of specified Job
 * `hpe-icsp.icsp_mid_get` - Retrieve ICSP ID (MID) for Specified Server
+* `hpe-icsp.icsp_multi_server_attribute_add` - Apply Attribute with server unique values across multiple servers.
+* `hpe-icsp.icsp_server_attributes_add` - Assign custom cttributes to server
+* `hpe-icsp.icsp_server_attributes_del` - Remove custom attribute from server
+* `hpe-icsp.icsp_server_attributes_get` - Retrieve attributes set against server
+* `hpe-icsp.icsp_server_data_format` - Generates the json object used in the buildplan apply action
 * `hpe-icsp.icsp_server_delete` - Remove server record from ICSP instance
 * `hpe-icsp.icsp_server_details_get` - Return Summary information on server
-* `hpe-icsp.icsp_ca_cert` - Retrieve certificate for ICSP server
-* `hpe-icsp.icsp_id_to_os` - Allow for the application of build plans to a single UUID or Serial number.

--- a/packs/hpe-icsp/actions/icsp_ids_to_os.yaml
+++ b/packs/hpe-icsp/actions/icsp_ids_to_os.yaml
@@ -4,7 +4,7 @@ runner_type: "mistral-v2"
 pack: "hpe-icsp"
 enabled: true
 entry_point: "workflows/icsp_ids_to_os.yaml"
-description: "Apply OS Build plans to a series of Machine Serial Number/UUIDs."
+description: "Apply OS Build plans to a series of Machine Serial Number/UUIDs. This will creata a batch job in ICSP for the specified servers."
 
 parameters:
   identifiers:

--- a/packs/hpe-icsp/actions/icsp_ids_to_os.yaml
+++ b/packs/hpe-icsp/actions/icsp_ids_to_os.yaml
@@ -4,7 +4,7 @@ runner_type: "mistral-v2"
 pack: "hpe-icsp"
 enabled: true
 entry_point: "workflows/icsp_ids_to_os.yaml"
-description: "Apply OS Build plans to a series of Machine Serial Number/UUIDs. This will creata a batch job in ICSP for the specified servers."
+description: "Apply OS Build plans to a series of Machine Serial Number/UUIDs. This will create a batch job in ICSP for the specified servers."
 
 parameters:
   identifiers:

--- a/packs/hpe-icsp/actions/icsp_mid_get.py
+++ b/packs/hpe-icsp/actions/icsp_mid_get.py
@@ -21,7 +21,7 @@ class GetMid(ICSPBaseActions):
 
         self.set_connection(connection_details)
         self.get_sessionid()
-        mids = self.get_MIDs(identifiers, identifier_type)
+        mids = self.get_mids(identifiers, identifier_type)
 
         if mids:
             if len(mids) == 1:

--- a/packs/hpe-icsp/actions/icsp_mid_get.py
+++ b/packs/hpe-icsp/actions/icsp_mid_get.py
@@ -17,30 +17,17 @@ from lib.icsp import ICSPBaseActions
 
 
 class GetMid(ICSPBaseActions):
-    def run(self, uuid=None, serialnumber=None, connection_details=None):
+    def run(self, identifiers, identifier_type, connection_details=None):
 
         self.set_connection(connection_details)
         self.get_sessionid()
         endpoint = "/rest/os-deployment-servers"
-        getresults = self.icsp_get(endpoint)
-        servers = getresults["members"]
-        results = []
-        # Checking arrays are set otherwise errors occur later
-        # when called within flows missing arrays cause python errors
-        if not serialnumber:
-            serialnumber = []
-        if not uuid:
-            uuid = []
-        for server in servers:
-            if (server["uuid"] in uuid) or\
-                    (server["serialNumber"] in serialnumber):
-                if (len(uuid) + len(serialnumber)) == 1:
-                    return {'mid': int(server["mid"])}
-                else:
-                    if server["mid"] not in results:
-                        results.append(int(server["mid"]))
+        mids = self.get_MIDs(identifiers, identifier_type)
 
-        if results:
-            return results
+        if mids:
+            if len(mids) == 1:
+                return {'mid': int(mids[0])}
+            elif len(mids) > 1:
+               return mids
         else:
             raise ValueError("No Servers Found")

--- a/packs/hpe-icsp/actions/icsp_mid_get.py
+++ b/packs/hpe-icsp/actions/icsp_mid_get.py
@@ -21,13 +21,12 @@ class GetMid(ICSPBaseActions):
 
         self.set_connection(connection_details)
         self.get_sessionid()
-        endpoint = "/rest/os-deployment-servers"
         mids = self.get_MIDs(identifiers, identifier_type)
 
         if mids:
             if len(mids) == 1:
                 return {'mid': int(mids[0])}
             elif len(mids) > 1:
-               return mids
+                return mids
         else:
             raise ValueError("No Servers Found")

--- a/packs/hpe-icsp/actions/icsp_mid_get.yaml
+++ b/packs/hpe-icsp/actions/icsp_mid_get.yaml
@@ -5,16 +5,20 @@
   enabled: true
   entry_point: "icsp_mid_get.py"
   parameters:
-    uuid:
+    identifiers:
       type: "array"
-      description: "UUID of the Machine to retreive."
-      required: false
+      description: "List of host identifiers (mid,serialnumber or uuid). Must be on a single type."
+      required: true
       position: 0
-    serialnumber:
-      type: "array"
-      description: "Serial Number of server to find."
-      required: false
+    identifier_type:
+      type: "string"
+      description: "What type of Identifiers have been provided"
+      required: true
+      default: "mid"
       position: 1
+      enum:
+        - serialnumber
+        - uuid
     connection_details:
       type: "object"
       description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"

--- a/packs/hpe-icsp/actions/icsp_multi_server_attribute_add.yaml
+++ b/packs/hpe-icsp/actions/icsp_multi_server_attribute_add.yaml
@@ -18,7 +18,7 @@ parameters:
     type: string
     enum:
       - serialnumber
-      - UUID
+      - uuid
     default: serialnumber
   attribute_key:
     required: true

--- a/packs/hpe-icsp/actions/icsp_server_data_format.py
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.py
@@ -17,7 +17,7 @@ from lib.icsp import ICSPBaseActions
 
 
 class FormatServerData(ICSPBaseActions):
-    def run(self, identifiers, identifier_type,  hostnames,
+    def run(self, identifiers, identifier_type, hostnames,
             domains=None, workgroups=None, connection_details=None):
         if identifier_type == "mid":
             for n in identifiers:

--- a/packs/hpe-icsp/actions/icsp_server_data_format.py
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.py
@@ -17,11 +17,12 @@ from lib.icsp import ICSPBaseActions
 
 
 class FormatServerData(ICSPBaseActions):
-    def run(self, identifiers, identifier_type,  hostnames, domains=None, workgroups=None, connection_details=None):
+    def run(self, identifiers, identifier_type,  hostnames,
+            domains=None, workgroups=None, connection_details=None):
         if identifier_type == "mid":
             for n in identifiers:
                 try:
-                  test = int(n) 
+                    int(n)
                 except:
                     raise ValueError("Identifier provides is not a MID")
             mids = identifiers

--- a/packs/hpe-icsp/actions/icsp_server_data_format.py
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.py
@@ -39,6 +39,7 @@ class FormatServerData(ICSPBaseActions):
                         values['workgroup'] = workgroups[i]
                 output[mids[i]] = values
         else:
-            raise ValueError("MID and Hostname Array counts do not match")
+            raise ValueError('Matched IDs and Hostname Array counts do '
+                             'not match. Check identifiers and hostnames')
 
         return output

--- a/packs/hpe-icsp/actions/icsp_server_data_format.py
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.py
@@ -17,7 +17,18 @@ from lib.icsp import ICSPBaseActions
 
 
 class FormatServerData(ICSPBaseActions):
-    def run(self, mids, hostnames, domains=None, workgroups=None):
+    def run(self, identifiers, identifier_type,  hostnames, domains=None, workgroups=None, connection_details=None):
+        if identifier_type == "mid":
+            for n in identifiers:
+                try:
+                  test = int(n) 
+                except:
+                    raise ValueError("Identifier provides is not a MID")
+            mids = identifiers
+        else:
+            self.set_connection(connection_details)
+            self.get_sessionid()
+            mids = self.get_MIDs(identifiers, identifier_type)
         if len(mids) == len(hostnames):
             output = {}
             for i in range(len(mids)):

--- a/packs/hpe-icsp/actions/icsp_server_data_format.py
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.py
@@ -20,11 +20,7 @@ class FormatServerData(ICSPBaseActions):
     def run(self, identifiers, identifier_type, hostnames,
             domains=None, workgroups=None, connection_details=None):
         if identifier_type == "mid":
-            for n in identifiers:
-                try:
-                    int(n)
-                except:
-                    raise ValueError("Identifier provides is not a MID")
+            self.validate_mids(identifiers)
             mids = identifiers
         else:
             self.set_connection(connection_details)

--- a/packs/hpe-icsp/actions/icsp_server_data_format.py
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.py
@@ -29,7 +29,7 @@ class FormatServerData(ICSPBaseActions):
         else:
             self.set_connection(connection_details)
             self.get_sessionid()
-            mids = self.get_MIDs(identifiers, identifier_type)
+            mids = self.get_mids(identifiers, identifier_type)
         if len(mids) == len(hostnames):
             output = {}
             for i in range(len(mids)):

--- a/packs/hpe-icsp/actions/icsp_server_data_format.yaml
+++ b/packs/hpe-icsp/actions/icsp_server_data_format.yaml
@@ -5,16 +5,33 @@
   enabled: true
   entry_point: "icsp_server_data_format.py"
   parameters:
-    mids:
+    identifiers:
       type: "array"
-      description: "Array of MID values"
+      description: "List of host identifiers (mid,serialnumber or uuid). Must be on a single type."
       required: true
       position: 0
+    identifier_type:
+      type: "string"
+      description: "What type of Identifiers have been provided"
+      required: true
+      default: "mid"
+      position: 1
+      enum:
+        - mid
+        - serialnumber
+        - uuid
     hostnames:
       type: "array"
       description: "Array of hostname values"
       required: true
-      position: 1
+      position: 2
+    connection_details:
+      type: "object"
+      description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"
+      required: false
+      secret: true
+      position: 3
+
 # Disabled due to lack of testing.
 #    domains:
 #      type: "array"

--- a/packs/hpe-icsp/actions/icsp_server_details_get.py
+++ b/packs/hpe-icsp/actions/icsp_server_details_get.py
@@ -1,0 +1,25 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from lib.icsp import ICSPBaseActions
+
+
+class GetCA(ICSPBaseActions):
+    def run(self, mid, connection_details=None):
+        self.set_connection(connection_details)
+        self.get_sessionid()
+        endpoint = "/rest/os-deployment-servers/%s" % mid
+
+        return self.icsp_get(endpoint)

--- a/packs/hpe-icsp/actions/icsp_server_details_get.yaml
+++ b/packs/hpe-icsp/actions/icsp_server_details_get.yaml
@@ -1,0 +1,18 @@
+---
+  name: "icsp_server_details_get"
+  runner_type: "run-python"
+  description: "Retrieve details for specified server"
+  enabled: true
+  entry_point: "icsp_server_details_get.py"
+  parameters:
+    mid:
+      type: "integer"
+      description: "MID of Server to retrieve"
+      required: true
+      position: 0
+    connection_details:
+      type: "object"
+      description: "Connection details. eg { \"host\": \"192.168.0.1\", \"user\":\"username\", \"pass\": \"secret\" }"
+      required: false
+      secret: true
+      position: 1

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -88,6 +88,13 @@ class ICSPBaseActions(Action):
                         mids.append(int(server["mid"]))
         return mids
 
+    def validate_mids (self, identifiers):
+        for n in identifiers:
+            try:
+                int(n)
+            except:
+                raise ValueError("Identifier provided is not a MID")
+    
     def icsp_get(self, endpoint):
         url = 'https://%s%s' % (self.icsp_host, endpoint)
         headers = copy.copy(self.base_headers)

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -80,11 +80,11 @@ class ICSPBaseActions(Action):
         # the ID order not the icsp server order
         for id in ids:
             for server in servers:
-                if (((idtype == 'serialnumber'
-                    and server["serialNumber"] == id)
-                        or (idtype == 'uuid'
-                            and server["uuid"] == id))
-                        and server["mid"] not in mids):
+                if (((idtype == 'serialnumber' and
+                    server["serialNumber"] == id) or
+                        (idtype == 'uuid' and
+                            server["uuid"] == id)) and
+                        server["mid"] not in mids):
                                 mids.append(int(server["mid"]))
         return mids
 

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -88,13 +88,13 @@ class ICSPBaseActions(Action):
                         mids.append(int(server["mid"]))
         return mids
 
-    def validate_mids (self, identifiers):
+    def validate_mids(self, identifiers):
         for n in identifiers:
             try:
                 int(n)
             except:
                 raise ValueError("Identifier provided is not a MID")
-    
+
     def icsp_get(self, endpoint):
         url = 'https://%s%s' % (self.icsp_host, endpoint)
         headers = copy.copy(self.base_headers)

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -76,16 +76,16 @@ class ICSPBaseActions(Action):
         getresults = self.icsp_get(endpoint)
         servers = getresults["members"]
         mids = []
+        # id then server loop to ensure results match
+        # the ID order not the icsp server order
         for id in ids:
             for server in servers:
-                if idtype == 'serialnumber':
-                    if ((server["serialNumber"] == id) and
-                            (server["mid"] not in mids)):
-                        mids.append(int(server["mid"]))
-                if idtype == 'uuid':
-                    if ((server["uuid"] == id) and
-                            (server["mid"] not in mids)):
-                        mids.append(int(server["mid"]))
+                if (((idtype == 'serialnumber'
+                    and server["serialNumber"] == id)
+                        or (idtype == 'uuid'
+                            and server["uuid"] == id))
+                        and server["mid"] not in mids):
+                                mids.append(int(server["mid"]))
         return mids
 
     def validate_mids(self, identifiers):

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -63,7 +63,7 @@ class ICSPBaseActions(Action):
 
         # added here due to the requirement of the session id
         self.base_headers = {'Auth': self.icsp_sessionid,
-                   'X-Api-Version': self.icsp_apiv}
+                             'X-Api-Version': self.icsp_apiv}
 
         return results["sessionID"]
 
@@ -79,10 +79,12 @@ class ICSPBaseActions(Action):
         for id in ids:
             for server in servers:
                 if idtype == 'serialnumber':
-                    if ((server["serialNumber"] == id) and (server["mid"] not in mids)):
+                    if ((server["serialNumber"] == id) and
+                            (server["mid"] not in mids)):
                         mids.append(int(server["mid"]))
                 if idtype == 'uuid':
-                    if ((server["uuid"] == id) and (server["mid"] not in mids)):
+                    if ((server["uuid"] == id) and
+                            (server["mid"] not in mids)):
                         mids.append(int(server["mid"]))
         return mids
 

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -71,7 +71,7 @@ class ICSPBaseActions(Action):
         jobid = str(joburi)
         return int(jobid.split("/")[-1])
 
-    def get_MIDs(self, ids, idtype):
+    def get_mids(self, ids, idtype):
         endpoint = "/rest/os-deployment-servers"
         getresults = self.icsp_get(endpoint)
         servers = getresults["members"]

--- a/packs/hpe-icsp/actions/lib/icsp.py
+++ b/packs/hpe-icsp/actions/lib/icsp.py
@@ -71,6 +71,21 @@ class ICSPBaseActions(Action):
         jobid = str(joburi)
         return int(jobid.split("/")[-1])
 
+    def get_MIDs(self, ids, idtype):
+        endpoint = "/rest/os-deployment-servers"
+        getresults = self.icsp_get(endpoint)
+        servers = getresults["members"]
+        mids = []
+        for id in ids:
+            for server in servers:
+                if idtype == 'serialnumber':
+                    if ((server["serialNumber"] == id) and (server["mid"] not in mids)):
+                        mids.append(int(server["mid"]))
+                if idtype == 'uuid':
+                    if ((server["uuid"] == id) and (server["mid"] not in mids)):
+                        mids.append(int(server["mid"]))
+        return mids
+
     def icsp_get(self, endpoint):
         url = 'https://%s%s' % (self.icsp_host, endpoint)
         headers = copy.copy(self.base_headers)

--- a/packs/hpe-icsp/actions/workflows/icsp_multi_server_attribute_add.yaml
+++ b/packs/hpe-icsp/actions/workflows/icsp_multi_server_attribute_add.yaml
@@ -13,7 +13,6 @@ workflows:
       - id_type
       - attribute_key
       - attribute_values 
-      #- function
       - connection_details
 
     tasks:
@@ -30,7 +29,6 @@ workflows:
           id_type: <% $.id_type %>
           key: <% $.attribute_key %>
           value: <% $.value %>
-          #function: <% $.function %>
           connection_details: <% $.connection_details %>
 
   single_run:
@@ -41,35 +39,17 @@ workflows:
       - id_type
       - key
       - value
-      #- function
       - connection_details
     
     tasks:
-      fork_mid_get:
-        on-success:
-          - get_mid_uuid: <% $.id_type = 'UUID' %>
-          - get_mid_sn: <% $.id_type = 'serialnumber' %>
-
-      get_mid_uuid:
+      get_mid:
         action: hpe-icsp.icsp_mid_get
         input:
-          uuid: [<% $.identifier %>]
+          identifiers: [<% $.identifier %>]
+          identifier_type: <% $.id_type %>
           connection_details: <% $.connection_details %>
         publish:
-          icsp_mid: <% $.get_mid_uuid.result.mid %>
-        retry:
-          count: 5
-          delay: 120
-        on-success:
-          - set_attribute
-
-      get_mid_sn:
-        action: hpe-icsp.icsp_mid_get
-        input:
-          serialnumber: [<% $.identifier %>]
-          connection_details: <% $.connection_details %>
-        publish:
-          icsp_mid: <% $.get_mid_sn.result.mid %>
+          icsp_mid: <% $.get_mid.result.mid %>
         retry:
           count: 5
           delay: 120
@@ -82,5 +62,4 @@ workflows:
           mid: <% $.icsp_mid %>
           attribute_key: <% $.key %>
           attribute_value: <% $.value %>
-          #function: <% $.function %>
           connection_details: <% $.connection_details %>

--- a/packs/hpe-icsp/pack.yaml
+++ b/packs/hpe-icsp/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : hpe-icsp
 description : Pack for HP Enterprise Insight Control Server Provisioning Integration
-version : 0.2
+version : 0.3
 author : Paul Mulvihill
 email : paul.mulvihill@pulsant.com


### PR DESCRIPTION
## HPE-ICSP

### Status 
- pack extension

### Description

Refining Pack post real world application. Reduced load on mistral for multi server buildplan application.
Centralise get_mid function and adapt mid_get and server data format to use it.
Expanding server data format action to accept different Identifier types

Previous version of "ids to os" flow used "with item" feature to handle multiple servers. This method could hog Mistral delaying other calls. Update uses batch features of ICSP allowing this iterative work moved to actions.

Main action interface changes
* icsp_mid_get: merged serialnumber and uuid fields
* icsp_server_data_format: change mid field to identifiers and added identifier type

### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
