### PR TITLE
Add action alias unit test and improve error reporting for Orion.start_discovery

### DIFF
--- a/packs/orion/actions/lib/actions.py
+++ b/packs/orion/actions/lib/actions.py
@@ -186,8 +186,9 @@ class OrionBaseAction(Action):
         if len(orion_data['results']) == 1:
             return orion_data['results'][0]['ID']
         else:
-            raise ValueError(
-                "Failed to lookup community in Orion.Credential!")
+            msg = "Could not find community '{}' in Orion.Credential!"
+            send_user_error(msg)
+            raise ValueError(msg)
 
     def get_engine_id(self, poller):
         """

--- a/packs/orion/actions/lib/actions.py
+++ b/packs/orion/actions/lib/actions.py
@@ -186,7 +186,8 @@ class OrionBaseAction(Action):
         if len(orion_data['results']) == 1:
             return orion_data['results'][0]['ID']
         else:
-            msg = "Could not find community '{}' in Orion.Credential!"
+            msg = "Could not get ID for community in Orion.Credential: {}".format(
+                community)
             send_user_error(msg)
             raise ValueError(msg)
 

--- a/packs/orion/actions/ncm_execute_script.py
+++ b/packs/orion/actions/ncm_execute_script.py
@@ -49,7 +49,7 @@ class NcmExecuteScript(OrionBaseAction):
             "Cirrus.ConfigArchive",
             "ExecuteScript",
             [orion_node.ncm_id],
-            "show failover")
+            script)
         results['job_id'] = orion_data[0]
 
         results['transfer'] = self.get_ncm_transfer_results(

--- a/packs/orion/pack.yaml
+++ b/packs/orion/pack.yaml
@@ -6,6 +6,6 @@ keywords:
    - orion
    - ncm
    - npm
-version: 0.4.0
+version: 0.4.1
 author: Jon Middleton
 email: jon.middleton@pulsant.com

--- a/packs/orion/tests/test_action_aliases.py
+++ b/packs/orion/tests/test_action_aliases.py
@@ -15,6 +15,48 @@
 from st2tests.base import BaseActionAliasTestCase
 
 
+class StartDiscovery(BaseActionAliasTestCase):
+    action_alias_name = "start_discovery"
+
+    def test_start_discovery(self):
+        format_string = self.action_alias_db.formats[0]['representation'][0]
+        format_strings = self.action_alias_db.get_format_strings()
+
+        command = "orion start discovery name run-import nodes 192.168.1.1 snmp public,private platform orion"
+        expected_parameters = {
+            'name': "run-import",
+            'nodes': "192.168.1.1",
+            'poller': 'primary',
+            'snmp_communities': "public,private",
+            'platform': "orion"
+        }
+        self.assertExtractedParametersMatch(format_string=format_string,
+                                            command=command,
+                                            parameters=expected_parameters)
+        self.assertCommandMatchesExactlyOneFormatString(
+            format_strings=format_strings,
+            command=command)
+
+    def test_start_discovery_poller(self):
+        format_string = self.action_alias_db.formats[0]['representation'][0]
+        format_strings = self.action_alias_db.get_format_strings()
+
+        command = "orion start discovery name run-import nodes 192.168.1.1 snmp public,private platform orion poller2"
+        expected_parameters = {
+            'name': "run-import",
+            'nodes': "192.168.1.1",
+            'poller': 'poller2',
+            'snmp_communities': "public,private",
+            'platform': "orion"
+        }
+        self.assertExtractedParametersMatch(format_string=format_string,
+                                            command=command,
+                                            parameters=expected_parameters)
+        self.assertCommandMatchesExactlyOneFormatString(
+            format_strings=format_strings,
+            command=command)
+
+
 class NcmConfigDownloadActionAliasTestCase(BaseActionAliasTestCase):
     action_alias_name = 'ncm_config_download'
 

--- a/packs/orion/tests/test_action_aliases.py
+++ b/packs/orion/tests/test_action_aliases.py
@@ -22,7 +22,7 @@ class StartDiscovery(BaseActionAliasTestCase):
         format_string = self.action_alias_db.formats[0]['representation'][0]
         format_strings = self.action_alias_db.get_format_strings()
 
-        command = "orion start discovery name run-import nodes 192.168.1.1 snmp public,private platform orion"
+        command = "orion start discovery name run-import nodes 192.168.1.1 snmp public,private platform orion"  # NOQA
         expected_parameters = {
             'name': "run-import",
             'nodes': "192.168.1.1",
@@ -41,7 +41,7 @@ class StartDiscovery(BaseActionAliasTestCase):
         format_string = self.action_alias_db.formats[0]['representation'][0]
         format_strings = self.action_alias_db.get_format_strings()
 
-        command = "orion start discovery name run-import nodes 192.168.1.1 snmp public,private platform orion poller2"
+        command = "orion start discovery name run-import nodes 192.168.1.1 snmp public,private platform orion poller2"  # NOQA
         expected_parameters = {
             'name': "run-import",
             'nodes': "192.168.1.1",


### PR DESCRIPTION
## Orion

### Status 

- bugfix
- complete

### Description

Improve error reporitng in orion.start_discovery on Orion not being able to return an ID for an SNMP community and add action alias unit tests.

### Checklist (tick everything that applies)

- [X] Version bump (required for changed packs)
- [X] Code linting (required, can be done after the PR checks)
- [X] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
