### PR TITLE
Add triggers to sensu and nagios pack

### DIFF
--- a/packs/nagios/triggers/service_state_change.yaml
+++ b/packs/nagios/triggers/service_state_change.yaml
@@ -1,0 +1,4 @@
+---
+name: service_state_change
+pack: nagios
+description: 'Trigger type for nagios service state change event.'

--- a/packs/sensu/triggers/event_handler.yaml
+++ b/packs/sensu/triggers/event_handler.yaml
@@ -1,0 +1,4 @@
+---
+name: event_handler
+pack: sensu
+description: 'Trigger type for sensu event handler.'


### PR DESCRIPTION
This pull request updates affected packs for https://github.com/StackStorm/st2/pull/2752 change.

It adds new triggers resource directory with corresponding trigger files for packs which need to register triggers which are not emitted by a sensor.

This functionality is fully backward compatible - `triggers/` directory is simply ignored in older versions of StackStorm. Trigger already exist errors is also expected and not-fatal so it also won't throw an exception is trigger has already been registered.

Until everyone upgrades to StackStorm v1.5 which includes this functionality, we can't remove trigger registration code from the service handler script.