### PR TITLE
Add config_demo pack

### DIFF
--- a/packs/config_demo/actions/print_config.py
+++ b/packs/config_demo/actions/print_config.py
@@ -1,0 +1,10 @@
+from pprint import pprint
+
+from st2actions.runners.pythonrunner import Action
+
+
+class PrintConfigAction(Action):
+    def run(self):
+        print('=========')
+        pprint(self.config)
+        print('=========')

--- a/packs/config_demo/actions/print_config.yaml
+++ b/packs/config_demo/actions/print_config.yaml
@@ -1,0 +1,6 @@
+---
+name: print_config
+runner_type: run-python
+description: Action which prints config values.
+enabled: true
+entry_point: print_config.py

--- a/packs/config_demo/config.schema.yaml
+++ b/packs/config_demo/config.schema.yaml
@@ -1,0 +1,20 @@
+---
+  api_key:
+    description: "API key"
+    type: "string"
+    secret: true
+    required: true
+  api_secret:
+    description: "API secret"
+    type: "string"
+    secret: true
+    required: true
+  region:
+    description: "API region to use"
+    type: "string"
+    required: true
+    default: "us-east-1"
+  private_key_path:
+    description: "Path to the private key file to use"
+    type: "string"
+    required: false

--- a/packs/config_demo/pack.yaml
+++ b/packs/config_demo/pack.yaml
@@ -1,0 +1,6 @@
+---
+name : config_demo
+description : Pack which demonstrated new pack configuration functionality available in StackStorm v1.5 and above.
+version : 0.1
+author : st2-dev
+email : info@stackstorm.com


### PR DESCRIPTION
This pack demonstrates some of the new pack configuration functionality available in StackStorm v1.5 and above.