### PR TITLE
Fix cloudformation related parsing bug in the AWS pack

### DIFF
--- a/packs/aws/actions/lib/ec2parsers.py
+++ b/packs/aws/actions/lib/ec2parsers.py
@@ -1,6 +1,8 @@
 import boto
 import six
 
+from boto import cloudformation
+
 
 class FieldLists():
     ADDRESS = [
@@ -182,7 +184,7 @@ class ResultSets(object):
             return self.parseTag(output)
         elif isinstance(output, boto.ec2.ec2object.EC2Object):
             return self.parseEC2Object(output)
-        elif isinstance(output, boto.cloudformation.stack.Stack):
+        elif isinstance(output, cloudformation.stack.Stack):
             return self.parseStackObject(output)
         elif isinstance(output, boto.rds.dbinstance.DBInstance):
             return self.parseDBInstanceObject(output)


### PR DESCRIPTION
It looks like that in newer versions of boto, you can't access `cloudformation` pack via the `boto` module anymore (might also be a bug in an upstream boto package, but didn't have time to dig in yet).


```python
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto
>>> boto.cloudformation.stack.Stack
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
AttributeError: 'module' object has no attribute 'cloudformation'
>>> from boto import cloudformation
>>> cloudformation.stack.Stack
<class 'boto.cloudformation.stack.Stack'>
```