### PR TITLE
Add config schema to aws pack, make it work with new improved configs

### DIFF
--- a/packs/aws/actions/lib/action.py
+++ b/packs/aws/actions/lib/action.py
@@ -15,27 +15,47 @@ class BaseAction(Action):
     def __init__(self, config):
         super(BaseAction, self).__init__(config)
 
+        self.credentials = {
+            'region': None,
+            'aws_access_key_id': None,
+            'aws_secret_access_key': None
+        }
+
         if config['st2_user_data']:
             with open(config['st2_user_data'], 'r') as fp:
                 self.userdata = fp.read()
         else:
             self.userdata = None
-        self.setup = config['setup']
+
+        # Note: In old static config credentials and region are under "setup" key and with a new
+        # dynamic config values are top-level
+        access_key_id = config.get('aws_access_key_id', None)
+        secret_access_key = config.get('aws_secret_access_key', None)
+        region = config.get('region', None)
+
+        if access_key_id and secret_access_key:
+            self.credentials['aws_access_key_id'] = access_key_id
+            self.credentials['aws_secret_access_key'] = secret_access_key
+            self.credentials['region'] = region
+        else:
+            # Assume old-style config
+            self.credentials = config['setup']
+
         self.resultsets = ResultSets()
 
     def ec2_connect(self):
-        region = self.setup['region']
-        del self.setup['region']
-        return boto.ec2.connect_to_region(region, **self.setup)
+        region = self.credentials['region']
+        del self.credentials['region']
+        return boto.ec2.connect_to_region(region, **self.credentials)
 
     def vpc_connect(self):
-        region = self.setup['region']
-        del self.setup['region']
-        return boto.vpc.connect_to_region(region, **self.setup)
+        region = self.credentials['region']
+        del self.credentials['region']
+        return boto.vpc.connect_to_region(region, **self.credentials)
 
     def r53_connect(self):
-        del self.setup['region']
-        return boto.route53.connection.Route53Connection(**self. setup)
+        del self.credentials['region']
+        return boto.route53.connection.Route53Connection(**self.credentials)
 
     def get_r53zone(self, zone):
         conn = self.r53_connect()
@@ -91,8 +111,8 @@ class BaseAction(Action):
             del kwargs['zone']
             obj = self.get_r53zone(zone)
         else:
-            del self.setup['region']
-            obj = getattr(module, cls)(**self.setup)
+            del self.credentials['region']
+            obj = getattr(module, cls)(**self.credentials)
         resultset = getattr(obj, action)(**kwargs)
         formatted = self.resultsets.formatter(resultset)
         return formatted if isinstance(formatted, list) else [formatted]

--- a/packs/aws/actions/lib/action.py
+++ b/packs/aws/actions/lib/action.py
@@ -113,6 +113,11 @@ class BaseAction(Action):
         else:
             del self.credentials['region']
             obj = getattr(module, cls)(**self.credentials)
+
+        if not obj:
+            raise ValueError('Invalid or missing credentials (aws_access_key_id,'
+                             'aws_secret_access_key) or region')
+
         resultset = getattr(obj, action)(**kwargs)
         formatted = self.resultsets.formatter(resultset)
         return formatted if isinstance(formatted, list) else [formatted]

--- a/packs/aws/actions/lib/action.py
+++ b/packs/aws/actions/lib/action.py
@@ -14,8 +14,10 @@ class BaseAction(Action):
 
     def __init__(self, config):
         super(BaseAction, self).__init__(config)
-        if config['st2_user_data'] is not "":
-            self.userdata = open(config['st2_user_data'], 'r').read()
+
+        if config['st2_user_data']:
+            with open(config['st2_user_data'], 'r') as fp:
+                self.userdata = fp.read()
         else:
             self.userdata = None
         self.setup = config['setup']

--- a/packs/aws/config.schema.yaml
+++ b/packs/aws/config.schema.yaml
@@ -13,4 +13,4 @@
     description: "AWS region to use."
     type: "string"
     required: true
-    default: null
+    default: 'us-east-1'

--- a/packs/aws/config.schema.yaml
+++ b/packs/aws/config.schema.yaml
@@ -1,0 +1,16 @@
+---
+  aws_access_key_id:
+    description: "AWS access key to use."
+    type: "string"
+    secret: true
+    required: true
+  aws_secret_access_key:
+    description: "AWS access secret to use."
+    type: "string"
+    secret: true
+    required: true
+  region:
+    description: "AWS region to use."
+    type: "string"
+    required: true
+    default: null

--- a/packs/aws/config.yaml
+++ b/packs/aws/config.yaml
@@ -1,8 +1,15 @@
 ---
+# Note: credentials under "setup" object are deprecated and have been replaced
+# with top-level values which have precedence and also work with dynamic config
+# values.
 setup:
   region: ""
   aws_access_key_id: null
   aws_secret_access_key: null
+
+aws_access_key_id: null
+aws_secret_access_key: null
+region: ""
 interval: 20
 st2_user_data: "/opt/stackstorm/packs/aws/actions/scripts/bootstrap_user.sh"
 


### PR DESCRIPTION
This pull request adds config schema to the aws pack and makes it work with the new dynamic configs.

New dynamic config items don't support nested configs so I needed to make some changes the code so it's backward compatible and supports both approaches.

Hopefully in the near future we can update all the configs and reduce the nested items (keep them flat).

Here is an example of a new  `aws.yaml` config file which uses user-specific credentials, but the same shared region:

```yaml
---
aws_access_key_id: "{{user.aws_access_key_id}}"
aws_secret_access_key: "{{user.aws_secret_access_key}}"
region: "us-east-1"
```