### PR TITLE
RFR: Fix package_cloud destroy token actions

### DIFF
--- a/packs/packagecloud/actions/destroy_master_token.yaml
+++ b/packs/packagecloud/actions/destroy_master_token.yaml
@@ -20,4 +20,4 @@ parameters:
     default: true
   cmd:
     immutable: true
-    default: "package_cloud master_token destroy {{user}}/{{repository}} {{token_name}}"
+    default: "echo y | package_cloud master_token destroy {{user}}/{{repository}} {{token_name}}"

--- a/packs/packagecloud/actions/destroy_master_token.yaml
+++ b/packs/packagecloud/actions/destroy_master_token.yaml
@@ -11,15 +11,13 @@ parameters:
   repository:
     type: string
     required: true
-  mastertoken:
-    type: string
-    required: true
   token_name:
     type: string
     required: true
+    description: "Not the token value but the name used. See https://packagecloud.io/docs#revocation."
   sudo:
     immutable: true
     default: true
   cmd:
     immutable: true
-    default: "package_cloud master_token destroy {{user}}/{{repository}} {{mastertoken}} {{token_name}}"
+    default: "package_cloud master_token destroy {{user}}/{{repository}} {{token_name}}"

--- a/packs/packagecloud/actions/destroy_read_token.yaml
+++ b/packs/packagecloud/actions/destroy_read_token.yaml
@@ -11,15 +11,17 @@ parameters:
   repository:
     type: string
     required: true
-  mastertoken:
+  master_token_name:
     type: string
     required: true
-  readtoken:
+    description: "Not the token value but the name used. See https://packagecloud.io/docs#revocation."
+  read_token_name:
     type: string
     required: true
+    description: "Not the token value but the name used. See https://packagecloud.io/docs#revocation."
   sudo:
     immutable: true
     default: true
   cmd:
     immutable: true
-    default: "package_cloud read_token destroy {{user}}/{{repository}} {{mastertoken}}/{{readtoken}}"
+    default: "package_cloud read_token destroy {{user}}/{{repository}} {{master_token_name}}/{{read_token_name}}"


### PR DESCRIPTION
See https://packagecloud.io/docs#revocation. 

I was wondering what kind of idiots would require us to pass the token value to delete? It turns out our actions were wrong. They don't require us to pass the values but just the name. 

## Sample run:

``` 
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯ package_cloud master_token destroy stackstorm/enterprise TRUMP
Looking for repository at stackstorm/enterprise... Using https://packagecloud.io with token:******a7e9
success!

Are you sure you want to delete TRUMP?:
```

Unfortunately, this requires user input. There is no --force option or -y. 

```
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯ package_cloud master_token destroy stackstorm/enterprise TRUMP -f
ERROR: "package_cloud destroy" was called with arguments ["stackstorm/enterprise", "TRUMP", "-f"]
Usage: "package_cloud destroy user/repository token_name"
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯ package_cloud master_token destroy stackstorm/enterprise TRUMP --yes
ERROR: "package_cloud destroy" was called with arguments ["stackstorm/enterprise", "TRUMP", "--yes"]
Usage: "package_cloud destroy user/repository token_name"
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯ package_cloud master_token destroy stackstorm/enterprise TRUMP -y
ERROR: "package_cloud destroy" was called with arguments ["stackstorm/enterprise", "TRUMP", "-y"]
Usage: "package_cloud destroy user/repository token_name"
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯
```

## Work around 

```
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯ echo y | package_cloud master_token destroy stackstorm/enterprise TRUMP
Looking for repository at stackstorm/enterprise... Using https://packagecloud.io with token:******a7e9
success!

Are you sure you want to delete TRUMP?: Attempting to destroy token named TRUMP... success!
(virtualenv)vagrant@st2dev /m/s/s/st2contrib ❯❯❯
```

And issue filed with package_cloud for `--force`: https://packagecloud-users.slack.com/archives/general/p1470153651000165 

