### PR TITLE
Add filename filter to packagecloud.list_packages action

### DIFF
--- a/packs/packagecloud/actions/list_packages.py
+++ b/packs/packagecloud/actions/list_packages.py
@@ -1,0 +1,27 @@
+import fnmatch
+
+import requests
+
+from st2actions.runners.pythonrunner import Action
+
+URL = 'https://%(api_token)s:@packagecloud.io/api/v1/repos/%(repo)s/packages.json'
+
+
+class ListPackagesAction(Action):
+    def run(self, repo, api_token, per_page=1000, filename_filter=None):
+        values = {'repo': repo, 'api_token': api_token}
+        url = URL % values
+        params = {'per_page': per_page}
+
+        response = requests.get(url, params=params)
+        data = response.json()
+
+        if not filename_filter:
+            return data
+
+        result = []
+        for item in data:
+            if fnmatch.fnmatch(item['filename'], filename_filter):
+                result.append(item)
+
+        return result

--- a/packs/packagecloud/actions/list_packages.yaml
+++ b/packs/packagecloud/actions/list_packages.yaml
@@ -2,7 +2,8 @@
 name: list_packages
 pack: packagecloud
 description: List packages for a repo
-runner_type: http-request
+runner_type: python-script
+entry_point: list_packages.py
 enabled: true
 parameters:
     repo:
@@ -13,13 +14,10 @@ parameters:
         type: string
         description: Token to access the packagecloud API
         default: "{{system.pkg_cloud_token}}"
-    url:
+    per_page:
+        type: number
+        default: 1000
+    filename_filter:
         type: string
-        immutable: true
-        default: "https://{{api_token}}:@packagecloud.io/api/v1/repos/{{repo}}/packages.json"
-    # Note: By default only returns first 30 items in chronological order. Another options is
-    # to implement handling of pagination.
-    params:
-        type: object
-        default:
-            per_page: 1000
+        description: "Optional glob-like filename filter (e.g. *1.6.0)*"
+        required: false

--- a/packs/packagecloud/requirements.txt
+++ b/packs/packagecloud/requirements.txt
@@ -1,0 +1,1 @@
+requests


### PR DESCRIPTION
This pull request adds a glob-like filename filter to the `packagecloud.list_packages`.

By specifying this filter we can pre-filter the result before passing it to Mistral. This way we don't break and overload Mistral (happens now) if result contains a lost of objects (aka a lot of packages).

Example filter parameter value: `*1.6.0`.