### PR TITLE
Fix pagination in package cloud list packages

### DIFF
--- a/packs/packagecloud/actions/list_packages.py
+++ b/packs/packagecloud/actions/list_packages.py
@@ -1,27 +1,56 @@
-import fnmatch
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional pkg_information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
 
 import requests
+import six.moves.http_client as http_client
 
-from st2actions.runners.pythonrunner import Action
-
-URL = 'https://%(api_token)s:@packagecloud.io/api/v1/repos/%(repo)s/packages.json'
+from st2actions.runners import pythonrunner
 
 
-class ListPackagesAction(Action):
-    def run(self, repo, api_token, per_page=1000, filename_filter=None):
-        values = {'repo': repo, 'api_token': api_token}
-        url = URL % values
-        params = {'per_page': per_page}
+class ListPackagesAction(pythonrunner.Action):
 
-        response = requests.get(url, params=params)
-        data = response.json()
+    def run(self, repo, package, distro_version, version, release, api_token, url):
+        page = 1
+        packages = []
 
-        if not filename_filter:
-            return data
+        while page < 100:
+            page_url = url + '?page=' + str(page)
+            response = requests.get(page_url)
 
-        result = []
-        for item in data:
-            if fnmatch.fnmatch(item['filename'], filename_filter):
-                result.append(item)
+            if response.status_code != http_client.OK:
+                raise Exception(response.text)
 
-        return result
+            packages += response.json()
+
+            if len(packages) >= int(response.headers.get('Total', 0)):
+                break
+
+            page += 1
+
+        if package:
+            packages = [pkg_info for pkg_info in packages if pkg_info['name'] == package]
+
+        if distro_version:
+            packages = [
+                pkg_info for pkg_info in packages if pkg_info['distro_version'] == distro_version
+            ]
+
+        if version:
+            packages = [pkg_info for pkg_info in packages if pkg_info['version'] == version]
+
+        if release:
+            packages = [pkg_info for pkg_info in packages if pkg_info['release'] == release]
+
+        return sorted(packages, key=lambda x: (x['version'], x['release']), reverse=True)

--- a/packs/packagecloud/actions/list_packages.yaml
+++ b/packs/packagecloud/actions/list_packages.yaml
@@ -10,14 +10,23 @@ parameters:
         type: string
         description: Name of the packagecloud repo
         required: true
+    package:
+        type: string
+        description: Select by specific packages
+    distro_version:
+        type: string
+        description: Select by specific distro
+    version:
+        type: string
+        description: Select by package version
+    release:
+        type: string
+        description: Select by release number
     api_token:
         type: string
         description: Token to access the packagecloud API
         default: "{{system.pkg_cloud_token}}"
-    per_page:
-        type: number
-        default: 1000
-    filename_filter:
+    url:
         type: string
-        description: "Optional glob-like filename filter (e.g. *1.6.0)*"
-        required: false
+        immutable: true
+        default: "https://{{api_token}}:@packagecloud.io/api/v1/repos/{{repo}}/packages.json"

--- a/packs/packagecloud/requirements.txt
+++ b/packs/packagecloud/requirements.txt
@@ -1,1 +1,2 @@
 requests
+six


### PR DESCRIPTION
## packagecloud

### Status 

Bug fix to list_packages. The list_packages only returns up to the page limit.

### Description

This patch replaces the list_packages with a python script that iterates thru all the pages.

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [ ] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)

