### PR TITLE
Jinja control concise output for package cloud create token

### DIFF
--- a/packs/packagecloud/actions/create_master_token.yaml
+++ b/packs/packagecloud/actions/create_master_token.yaml
@@ -5,6 +5,9 @@ pack: "packagecloud"
 runner_type: "local-shell-cmd"
 enabled: true
 parameters:
+  concise:
+    type: boolean
+    default: false
   user:
     type: string
     required: true
@@ -19,4 +22,4 @@ parameters:
     default: true
   cmd:
     immutable: true
-    default: "package_cloud master_token create {{user}}/{{repository}} {{token_name}}"
+    default: "package_cloud master_token create {{user}}/{{repository}} {{token_name}} {% if concise -%} | grep 'Master token' | awk '{ print $6}' {% endif %}"


### PR DESCRIPTION
## Problem

package_cloud master_token create produced output that also includes info other than token.

```
Looking for repository at <BLAH>... Using https://packagecloud.io with token:<BLEH>

    success!

    Attempting to create token named shit@pot.com... success!

    Master token shit@pot.com with value <TOKEN> created.'
```

For some use cases, we just that thing to output the token alone. Package cloud CLI doesn't have a `-t` or `--quiet` option. Hence the hack.

## Fun fact

st2ops001 was running with

```
  cmd:
    immutable: true
    default: "package_cloud master_token create {{user}}/{{repository}} {{token_name}} | grep 'Master token' | awk '{ print $6}'"
```

I just jinjaed it. 