### PR TITLE
Add get master token action

### DIFF
--- a/packs/packagecloud/actions/get_master_token.sh
+++ b/packs/packagecloud/actions/get_master_token.sh
@@ -1,0 +1,15 @@
+#! /bin/bash
+
+ORG=${1}
+REPO=${2}
+TOKEN_NAME=${3}
+
+output=$(package_cloud master_token list ${ORG}/${REPO} | grep ${TOKEN_NAME} | awk '{print $2}' |  tr -d '(|)')
+
+if [ -z ${output} ]; then
+    echo "No master token found!"
+    exit 1
+fi
+
+echo $output
+exit 0

--- a/packs/packagecloud/actions/get_master_token.yaml
+++ b/packs/packagecloud/actions/get_master_token.yaml
@@ -1,0 +1,29 @@
+---
+name: "get_master_token"
+description: "Get master token for user!"
+pack: "packagecloud"
+runner_type: "local-shell-script"
+entry_point: "get_master_token.sh"
+enabled: true
+parameters:
+  user:
+    type: string
+    required: true
+    position: 1
+
+  repository:
+    type: string
+    required: true
+    position: 2
+
+  token_name:
+    type: string
+    required: true
+    position: 3
+
+  timeout:  # XXX: Package cloud LIST master_tokens API call takes a while!
+    default: 300
+
+  sudo:
+    immutable: true
+    default: true


### PR DESCRIPTION
## Sample run

```(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run packagecloud.get_master_token user=stackstorm repository=enterprise token_name=yourmom@gmail.com env="HOME=/root"                                                                                                           ⏎ master ✭ ◼
..
id: 57b60c78d9d7ed258043c52b
status: succeeded
parameters:
  env:
    HOME: /root
  repository: enterprise
  token_name: yourmom@gmail.com
  user: stackstorm
result:
  failed: false
  return_code: 0
  stderr: ''
  stdout: REDACTED
  succeeded: true

```
```

(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯ st2 run packagecloud.get_master_token user=stackstorm repository=enterprise token_name=kamimom@gmail.com env="HOME=/root"                                                                                                             master ✭ ◼
..
id: 57b60d34d9d7ed258043c52e
status: failed
parameters:
  env:
    HOME: /root
  repository: enterprise
  token_name: kamimom@gmail.com
  user: stackstorm
result:
  failed: true
  return_code: 1
  stderr: ''
  stdout: No master token found!
  succeeded: false
(virtualenv)vagrant@st2dev /m/s/s/st2 ❯❯❯

```
```
