### PR TITLE
Fix the splunk.search action and add an action-alias.

### DIFF
--- a/packs/splunk/actions/search.py
+++ b/packs/splunk/actions/search.py
@@ -23,4 +23,4 @@ class OneShotSearch(Action):
         kwargs_oneshot = {"output_mode": "json"}
         result = self.service.jobs.oneshot(query, **kwargs_oneshot)
 
-        return result
+        return result.read()

--- a/packs/splunk/aliases/search.yaml
+++ b/packs/splunk/aliases/search.yaml
@@ -1,0 +1,11 @@
+---
+name: search
+action_ref: splunk.search
+description: Splunk one-shot search
+formats:
+   - "splunk one-shot {{ query }}"
+   - "splunk query {{ query }}"
+ack:
+   format: "Running splunk query \"{{ execution.parameters.query }}\""
+result:
+   format: "Splunk query results: {~} {{ execution.result }}"

--- a/packs/splunk/pack.yaml
+++ b/packs/splunk/pack.yaml
@@ -3,6 +3,6 @@ name: splunk
 description: Splunk integration pack
 keywords:
   - splunk
-version : 0.1
+version : 0.2
 author : st2-dev
 email : info@stackstorm.com


### PR DESCRIPTION
## Pack splunk

### Status 

- bugfix

### Description

Fix the splunk.search action to return the result object (currently returns a splunklib.binding.ResponseReader instance).

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
