### PR TITLE
Correct a reference of `Travis` to `Circle` in Circle CI pack.

### DIFF
--- a/packs/circle_ci/README.md
+++ b/packs/circle_ci/README.md
@@ -1,7 +1,7 @@
 # Circle CI Integration Pack
 
 Pack for integration of Circle CI into StackStorm. The pack includes the
-functionality to perform actions on Travis CI through StackStorm.
+functionality to perform actions on Circle CI through StackStorm.
 
 ## Actions
 


### PR DESCRIPTION
## Circle CI

### Status 

- bugfix.
- Complete.

### Description

Correct a typo in the README (so not increasing the pack version number).

### Checklist (tick everything that applies)

Correct a typo in the Circle CI README.md.