### PR TITLE
Adding the option to modify the maximum number of messages the sqs sensor can process

### DIFF
--- a/packs/aws/README.md
+++ b/packs/aws/README.md
@@ -118,6 +118,7 @@ following values in datastore:
 - aws.aws_access_key_id
 - aws.aws_secret_access_key
 - aws.region
+- aws.max_number_of_messages (must be between 1 - 10)
 
 For configuration in ``config.yaml`` with config like this
 
@@ -130,6 +131,8 @@ For configuration in ``config.yaml`` with config like this
       input_queues:
         - first_queue
         - second_queue
+    sqs_other:
+      max_mumber_of_messages: 1
 ```
 
 If any value exist in datastore it will be taken instead of any value in config.yaml

--- a/packs/aws/config.yaml
+++ b/packs/aws/config.yaml
@@ -22,4 +22,4 @@ sqs_sensor:
   input_queues:
 
 sqs_other:
-  max_mumber_of_messages: 1
+  max_number_of_messages: 1

--- a/packs/aws/config.yaml
+++ b/packs/aws/config.yaml
@@ -20,3 +20,6 @@ service_notifications_sensor:
 
 sqs_sensor:
   input_queues:
+
+sqs_other:
+  max_mumber_of_messages: 1

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -17,6 +17,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.6.5
+version : 0.6.6
 author : st2-dev
 email : info@stackstorm.com

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -61,7 +61,6 @@ class AWSSQSSensor(PollingSensor):
                                           num_messages=self.max_number_of_messages)
             for msg in msgs:
                 if msg:
-                    print msg
                     payload = {"queue": queue, "body": msg.body}
                     self._sensor_service.dispatch(trigger="aws.sqs_new_message", payload=payload)
                     msg.delete()

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -46,7 +46,7 @@ class AWSSQSSensor(PollingSensor):
         self.aws_region = self._get_config_entry('region')
 
         self.max_number_of_messages = self._get_config_entry('max_number_of_messages',
-                                                              prefix='sqs_other')
+                                                             prefix='sqs_other')
 
         self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
 

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -45,7 +45,8 @@ class AWSSQSSensor(PollingSensor):
         self.aws_secret_key = self._get_config_entry('aws_secret_access_key')
         self.aws_region = self._get_config_entry('region')
 
-        self.max_mumber_of_messages = self._get_config_entry('max_mumber_of_messages', prefix='sqs_other')
+        self.max_number_of_messages = self._get_config_entry('max_number_of_messages',
+                                                              prefix='sqs_other')
 
         self._logger = self._sensor_service.get_logger(name=self.__class__.__name__)
 
@@ -56,7 +57,8 @@ class AWSSQSSensor(PollingSensor):
 
     def poll(self):
         for queue in self.input_queues:
-            msgs = self._receive_messages(queue=self._get_queue_by_name(queue), num_messages=self.max_mumber_of_messages)
+            msgs = self._receive_messages(queue=self._get_queue_by_name(queue),
+                                          num_messages=self.max_number_of_messages)
             for msg in msgs:
                 if msg:
                     print msg

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -7,6 +7,7 @@ following values in datastore:
     - aws.aws_access_key_id
     - aws.aws_secret_access_key
     - aws.region
+    - aws.max_number_of_messages (must be between 1 - 10)
 For configuration in config.yaml with config like this
     setup:
       aws_access_key_id:
@@ -16,6 +17,8 @@ For configuration in config.yaml with config like this
       input_queues:
         - first_queue
         - second_queue
+    sqs_other:
+        max_number_of_messages: 1
 If any value exist in datastore it will be taken instead of any value in config.yaml
 """
 


### PR DESCRIPTION
## Pack AWS

### Status 

- adding feature

### Description

Added an option to the AWS SQS Sensor config that gives the option to modify the maximum number of messages the sqs sensor can process at one time. The current sensor is hard coded to 1. The new option will allow someone to use the AWS limit of 10.

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)