### PR TITLE
Psm/vsphere dist std networks

### DIFF
--- a/packs/vsphere/CHANGES.md
+++ b/packs/vsphere/CHANGES.md
@@ -15,3 +15,6 @@
   ## V0.4.2
   Updates to actions to factor in ST2 V2 changes forcing string conversions for output and publish variable syntax changes.
   vm_basic_build workflow introduction of 12 seconds delay between elements to support parrallel action load balancing
+
+  ## V0.4.3
+  Update nic actions to factor in Distributed Port Groups. When setting a network the DPG will be used over a standard port group of the same name

--- a/packs/vsphere/CHANGES.md
+++ b/packs/vsphere/CHANGES.md
@@ -17,4 +17,4 @@
   vm_basic_build workflow introduction of 12 seconds delay between elements to support parrallel action load balancing
 
   ## V0.4.3
-  Update nic actions to factor in Distributed Port Groups. When setting a network the DPG will be used over a standard port group of the same name
+  Update nic actions to factor in Distributed Port Groups. When setting a network the DPG will be used over a standard port group of the same name.

--- a/packs/vsphere/actions/vm_env_items_get.py
+++ b/packs/vsphere/actions/vm_env_items_get.py
@@ -41,6 +41,7 @@ class GetItems(BaseAction):
                  'DataStore': vim.Datastore,
                  'Virtual Machines': vim.VirtualMachine,
                  'Networks': vim.Network,
+                 'Distrubuted Portgroup': vim.DistributedVirtualPortgroup,
                  'Hosts': vim.HostSystem}
 
         objecttype = items[itemtype]

--- a/packs/vsphere/actions/vm_env_items_get.yaml
+++ b/packs/vsphere/actions/vm_env_items_get.yaml
@@ -17,6 +17,7 @@
         - DataStore
         - Virtual Machines
         - Networks
+        - Distrubuted Portgroup
         - Hosts
     parents:
         type: boolean

--- a/packs/vsphere/actions/vm_hw_nic_add.py
+++ b/packs/vsphere/actions/vm_hw_nic_add.py
@@ -45,12 +45,21 @@ class VMAddNic(BaseAction):
         self.establish_connection(vsphere)
 
         vm = inventory.get_virtualmachine(self.si_content, vm_id, vm_name)
-        network_obj = inventory.get_network(self.si_content, name=network_name)
+
+        try:
+            nettype = "dist"
+            network_obj = inventory.get_distributedportgroup(self.si_content,
+                                                             name=network_name)
+        except:
+            nettype = "std"
+            network_obj = inventory.get_network(self.si_content,
+                                                name=network_name)
 
         vm_reconfig_spec = self.get_vm_reconfig_spec(network_obj,
                                                      stayconnected,
                                                      nictype,
-                                                     wakeonlan)
+                                                     wakeonlan,
+                                                     nettype)
 
         add_vnic_task = vm.ReconfigVM_Task(spec=vm_reconfig_spec)
         successfully_added_vnic = self._wait_for_task(add_vnic_task)
@@ -58,7 +67,8 @@ class VMAddNic(BaseAction):
         return {'state': successfully_added_vnic}
 
     def get_vm_reconfig_spec(self, network_obj,
-                             stay_connected, network_type, wake_on_lan):
+                             stay_connected, network_type,
+                             wake_on_lan, nettype):
         network_spec = vim.vm.device.VirtualDeviceSpec()
         network_spec.operation = vim.vm.device.VirtualDeviceSpec.Operation.add
 
@@ -77,10 +87,29 @@ class VMAddNic(BaseAction):
 
         network_spec.device.wakeOnLanEnabled = wake_on_lan
         network_spec.device.deviceInfo = vim.Description()
-        network_spec.device.backing = \
-            vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
-        network_spec.device.backing.network = network_obj
-        network_spec.device.backing.deviceName = network_obj.name
+
+        # Default functionality is to use the
+        # Distributed Port Group over a standard group
+        if nettype == "dist":
+            network_spec.device.backing = \
+                vim.vm.device.VirtualEthernetCard\
+                .DistributedVirtualPortBackingInfo()
+            network_spec.device.backing.port = vim.dvs.PortConnection()
+
+            dvs_port_connection = vim.dvs.PortConnection()
+            dvs_port_connection.portgroupKey = network_obj.key
+            dvs_port_connection.switchUuid = \
+                network_obj.config.distributedVirtualSwitch.uuid
+
+            network_spec.device.backing = \
+                vim.vm.device.VirtualEthernetCard\
+                .DistributedVirtualPortBackingInfo()
+            network_spec.device.backing.port = dvs_port_connection
+        else:
+            network_spec.device.backing = \
+                vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+            network_spec.device.backing.network = network_obj
+            network_spec.device.backing.deviceName = network_obj.name
 
         network_spec.device.connectable = \
             vim.vm.device.VirtualDevice.ConnectInfo()

--- a/packs/vsphere/actions/vm_hw_nic_add.yaml
+++ b/packs/vsphere/actions/vm_hw_nic_add.yaml
@@ -23,7 +23,7 @@
         default: ~
       network_name:
         type: "string"
-        description: "Network to attach NIC to. Distributed Port Groups take presidence over Standard port Groups of the same name."
+        description: "Network to attach NIC to. Distributed Port Groups take precedence over Standard port Groups of the same name."
         required: true
       nictype:
         type: "string"

--- a/packs/vsphere/actions/vm_hw_nic_add.yaml
+++ b/packs/vsphere/actions/vm_hw_nic_add.yaml
@@ -23,7 +23,7 @@
         default: ~
       network_name:
         type: "string"
-        description: "Network to attach NIC to"
+        description: "Network to attach NIC to. Distributed Port Groups take presidence over Standard port Groups of the same name."
         required: true
       nictype:
         type: "string"

--- a/packs/vsphere/actions/vm_hw_nic_edit.py
+++ b/packs/vsphere/actions/vm_hw_nic_edit.py
@@ -46,8 +46,14 @@ class VMNicEdit(BaseAction):
         vm = inventory.get_virtualmachine(self.si_content,
                                           moid=vm_id,
                                           name=vm_name)
-        network_obj = inventory.get_network(self.si_content,
-                                            name=network_name)
+        try:
+            nettype = "dist"
+            network_obj = inventory.get_distributedportgroup(self.si_content,
+                                                             name=network_name)
+        except:
+            nettype = "std"
+            network_obj = inventory.get_network(self.si_content,
+                                                name=network_name)
 
         # find correct NIC
         for device in vm.config.hardware.device:
@@ -70,9 +76,31 @@ class VMNicEdit(BaseAction):
         # If network name provided assign new network
         # Room to expand the following to set additional flags/values
         if network_name:
-            new_spec.device.backing.network = network_obj
-            new_spec.device.backing.deviceName = network_obj.name
-            new_spec.device.deviceInfo.summary = network_obj.name
+            # Default functionality is to use the
+            # Distributed Port Group over a standard group
+            if nettype == "dist":
+                new_spec.device.backing = \
+                    vim.vm.device.VirtualEthernetCard\
+                    .DistributedVirtualPortBackingInfo()
+                new_spec.device.backing.port = vim.dvs.PortConnection()
+
+                dvs_port_connection = vim.dvs.PortConnection()
+                dvs_port_connection.portgroupKey = network_obj.key
+                dvs_port_connection.switchUuid = \
+                    network_obj.config.distributedVirtualSwitch.uuid
+
+                new_spec.device.backing = \
+                    vim.vm.device.VirtualEthernetCard\
+                    .DistributedVirtualPortBackingInfo()
+                new_spec.device.backing.port = dvs_port_connection
+            else:
+                new_spec.device.backing = \
+                    vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
+                new_spec.device.backing.network = network_obj
+                new_spec.device.backing.deviceName = network_obj.name
+            #new_spec.device.backing.network = network_obj
+            #new_spec.device.backing.deviceName = network_obj.name
+            #new_spec.device.deviceInfo.summary = network_obj.name
 
         # format changes for config spec update
         dev_changes = []

--- a/packs/vsphere/actions/vm_hw_nic_edit.py
+++ b/packs/vsphere/actions/vm_hw_nic_edit.py
@@ -98,9 +98,6 @@ class VMNicEdit(BaseAction):
                     vim.vm.device.VirtualEthernetCard.NetworkBackingInfo()
                 new_spec.device.backing.network = network_obj
                 new_spec.device.backing.deviceName = network_obj.name
-            #new_spec.device.backing.network = network_obj
-            #new_spec.device.backing.deviceName = network_obj.name
-            #new_spec.device.deviceInfo.summary = network_obj.name
 
         # format changes for config spec update
         dev_changes = []

--- a/packs/vsphere/actions/vm_hw_nic_edit.yaml
+++ b/packs/vsphere/actions/vm_hw_nic_edit.yaml
@@ -27,6 +27,6 @@
       required: true
     network_name:
       type: "string"
-      description: "Network Adapater should be connected to"
+      description: "Network Adapater should be connected to. Distributed Port Groups take presidence over Standard Port Groups of the same name "
       required: true
 

--- a/packs/vsphere/actions/vm_hw_nic_edit.yaml
+++ b/packs/vsphere/actions/vm_hw_nic_edit.yaml
@@ -27,6 +27,6 @@
       required: true
     network_name:
       type: "string"
-      description: "Network Adapater should be connected to. Distributed Port Groups take presidence over Standard Port Groups of the same name "
+      description: "Network Adapater should be connected to. Distributed Port Groups take precedence over Standard Port Groups of the same name "
       required: true
 

--- a/packs/vsphere/actions/vmwarelib/inventory.py
+++ b/packs/vsphere/actions/vmwarelib/inventory.py
@@ -93,6 +93,11 @@ def get_network(content, moid=None, name=None):
                               moid=moid, name=name)
 
 
+def get_distributedportgroup(content, moid=None, name=None):
+    return get_managed_entity(content, vim.dvs.DistributedVirtualPortgroup,
+                              moid=moid, name=name)
+
+
 def get_virtualmachine(content, moid=None, name=None):
     return get_managed_entity(content, vim.VirtualMachine,
                               moid=moid, name=name)

--- a/packs/vsphere/pack.yaml
+++ b/packs/vsphere/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : vsphere 
 description : st2 content pack containing vsphere integrations.
-version : 0.4.2
+version : 0.4.3
 author : Paul Mulvihill
 email : paul.mulvihill@pulsant.com


### PR DESCRIPTION
## VSphere

### Pack Extension/Bug Fix

### Description

Adding missing functionality to deal with distributed port groups in vsphere when setting network cards.

### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
