### PR TITLE
Add webhook and workflow to handle deployment events from GitHub.

### DIFF
--- a/packs/github/CHANGES.rst
+++ b/packs/github/CHANGES.rst
@@ -1,5 +1,12 @@
 # Changelog
 
+## v0.6.0
+
+* Add deployment event webhook.
+* Add deployment event workflow to trigger packs.install.
+* Add new action check_deployment_env env.
+* Add deployment_environment config option.
+
 ## v0.5.0
 
 * Migrate config.yaml to config.schema.yaml.

--- a/packs/github/README.md
+++ b/packs/github/README.md
@@ -91,3 +91,35 @@ StackStorm webhook handler.
 * ``get_issue`` - Retrieve information about a particular issue. Note: You
   only need to specify authentication token in the config if you use this
   action with a private repository.
+
+## Rules
+
+### github.deployment_event_webhook
+
+To enable this rule, run the following on the CLI (with a valid ST2 auth token):
+
+```bash
+st2 rule enable github.deployment_event_webhook
+```
+
+Then you should add a web hook in github sending deployment events to the following URL:
+
+`https://<st2-server>/api/v1/webhooks/github_deployment_event?st2-api-key=<ST2-API-KEY>`
+
+By default the enviroment is set to production, you can change this in
+your own config.yaml.
+
+You can then create a deployment via ChatOPS with the following
+command:
+
+```
+@hubot github deployment create me/my_st2_pack description Lets get the feature to production
+```
+
+#### Limiations
+
+- You need to have logged an OAuth key with StackStorm (via `github.store_oauth_token`).
+- It only works for the default `github_type`.
+- If using with GitHub.com you your ST2 server needs to be contactable via the internet!
+- Deployment Statuses will be logged as the creating user in GitHub.
+- You can't currently deploy tags, due to a limitation in `packs.download`.

--- a/packs/github/README.md
+++ b/packs/github/README.md
@@ -99,7 +99,7 @@ StackStorm webhook handler.
 To enable this rule, run the following on the CLI (with a valid ST2 auth token):
 
 ```bash
-st2 rule enable github.deployment_event_webhook
+st2 rule enable github.deploy_pack_on_deployment_event
 ```
 
 Then you should add a web hook in github sending deployment events to the following URL:
@@ -116,7 +116,7 @@ command:
 @hubot github deployment create me/my_st2_pack description Lets get the feature to production
 ```
 
-#### Limiations
+#### Limitations
 
 - You need to have logged an OAuth key with StackStorm (via `github.store_oauth_token`).
 - It only works for the default `github_type`.

--- a/packs/github/actions/check_deployment_env.py
+++ b/packs/github/actions/check_deployment_env.py
@@ -1,0 +1,27 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+from lib.base import BaseGithubAction
+
+
+class CheckDeploymentEnvAction(BaseGithubAction):
+    def run(self, deploy_env):
+
+        if deploy_env == self.config['deployment_environment']:
+            return True
+        else:
+            raise ValueError(
+                "No deployment, my env is '{}' and event for '{}'".format(
+                    deploy_env,
+                    self.config['deployment_environment']))

--- a/packs/github/actions/check_deployment_env.yaml
+++ b/packs/github/actions/check_deployment_env.yaml
@@ -1,0 +1,11 @@
+---
+name: "check_deployment_env"
+runner_type: "run-python"
+description: "Check if deployment event applies to this server."
+enabled: true
+entry_point: "check_deployment_env.py"
+parameters:
+  deploy_env:
+    type: "string"
+    description: "The deployement enviroment to check against the config value."
+    required: true

--- a/packs/github/actions/deployment_event.yaml
+++ b/packs/github/actions/deployment_event.yaml
@@ -1,0 +1,50 @@
+---
+name: "deployment_event"
+description: "Process an deployment event from GitHub."
+enabled: true
+entry_point: "workflows/deployment_event.yaml"
+
+runner_type: "mistral-v2"
+
+parameters:
+  repo_fullname:
+    type: "string"
+    description: "The full repo path (e.g. [Org|User]/repo_name"
+    required: true
+  repo_name:
+    type: "string"
+    description: "The repo name."
+    required: true
+  deploy_ref:
+    type: "string"
+    description: "The branch to deploy (Note: tags are not supported!)"
+    default: "master"
+  deploy_env:
+    type: "string"
+    description: "The enviroment to target."
+    default: "production"
+  deploy_sha:
+    type: "string"
+    description: "The SHA of the commit to deploy."
+    required: true
+  deploy_desc:
+    type: "string"
+    description: "The description of the deployment."
+    required: true
+  deploy_id:
+    type: "integer"
+    description: "The deployment ID."
+    required: true
+  ssh_url:
+    type: "string"
+    description: "The location of the repo for using with SSH."
+    required: true
+  creator:
+    type: "string"
+    description: "Who created the deployment (will be used to update the deployment status."
+    required: true
+  deploy_payload:
+    type: "string"
+    description: "Additional payload infomation from GitHub"
+    default: "{}"
+    immutable: true

--- a/packs/github/actions/deployment_event.yaml
+++ b/packs/github/actions/deployment_event.yaml
@@ -1,6 +1,6 @@
 ---
 name: "deployment_event"
-description: "Process an deployment event from GitHub."
+description: "Process an github deployment event and install a pack if the environment matches."
 enabled: true
 entry_point: "workflows/deployment_event.yaml"
 
@@ -21,7 +21,7 @@ parameters:
     default: "master"
   deploy_env:
     type: "string"
-    description: "The enviroment to target."
+    description: "The environment to target."
     default: "production"
   deploy_sha:
     type: "string"
@@ -45,6 +45,6 @@ parameters:
     required: true
   deploy_payload:
     type: "string"
-    description: "Additional payload infomation from GitHub"
+    description: "Additional payload information from GitHub"
     default: "{}"
     immutable: true

--- a/packs/github/actions/lib/base.py
+++ b/packs/github/actions/lib/base.py
@@ -70,12 +70,25 @@ class BaseGithubAction(Action):
             raise ValueError("Default GitHub Invalid!")
 
     def _get_user_token(self, user, enterprise):
-        if enterprise:
-            token_name = "token_enterprise_{}".format(user)
-        else:
-            token_name = "token_{}".format(user)
+        """
+        Return a users GitHub OAuth Token, if it fails replace '-'
+        with '.' as '.' is not valid for GitHub names.
+        """
 
-        return self.action_service.get_value(token_name)
+        if enterprise:
+            token_name = "token_enterprise_"
+        else:
+            token_name = "token_"
+
+        token = self.action_service.get_value(token_name + user)
+
+        # if a token is not returned, try using reversing changes made by
+        # GitHub Enterpise during LDAP sync'ing.
+        if token is None:
+            token = self.action_service.get_value(
+                token_name + user.replace("-", "."))
+
+        return token
 
     def _change_to_user_token(self, user, enterprise=False):
         token = self._get_user_token(user, enterprise)

--- a/packs/github/actions/workflows/deployment_event.yaml
+++ b/packs/github/actions/workflows/deployment_event.yaml
@@ -1,0 +1,68 @@
+---
+version: '2.0'
+
+github.deployment_event:
+  description: "A workflow to procress an github deployment event and install a pack if the enviroment matches."
+
+  input:
+    - repo_fullname
+    - repo_name
+    - deploy_ref
+    - deploy_env
+    - deploy_sha
+    - deploy_payload
+    - deploy_desc
+    - deploy_id
+    - ssh_url
+    - creator
+
+  tasks:
+    check_environment:
+      action: github.check_deployment_env
+
+      input:
+        deploy_env: <% $.deploy_env %>
+
+      on-success:
+        - install_pack
+
+      on-error:
+        - no_deloyment
+
+    install_pack:
+      action: packs.install
+
+      input:
+        packs: [  <% $.repo_name %> ]
+        repo_url: <% $.ssh_url %>
+        branch: <% $.deploy_ref %>
+        subtree: false
+
+      on-success:
+        - deployment_successful
+
+      on-error:
+        - deployment_error
+
+    deployment_successful:
+      action: github.create_deployment_status
+
+      input:
+        api_user: <% $.creator %>
+        repository: <% $.repo_fullname %>
+        deployment_id: <% $.deploy_id %>
+        state: "success"
+        description: "Completed deployment of <% $.repo_fullname %> on <% $.deploy_env %>."
+
+    deployment_error:
+      action: github.create_deployment_status
+
+      input:
+        api_user: <% $.creator %>
+        repository: <% $.repo_fullname %>
+        deployment_id: <% $.deploy_id %>
+        state: "failure"
+        description: "Failed deployment of <% $.repo_fullname %> on <% $.deploy_env %>."
+
+    no_deloyment:
+      action: core.noop

--- a/packs/github/actions/workflows/deployment_event.yaml
+++ b/packs/github/actions/workflows/deployment_event.yaml
@@ -2,7 +2,7 @@
 version: '2.0'
 
 github.deployment_event:
-  description: "A workflow to procress an github deployment event and install a pack if the enviroment matches."
+  description: "A workflow to process an github deployment event and install a pack if the environment matches."
 
   input:
     - repo_fullname

--- a/packs/github/config.schema.yaml
+++ b/packs/github/config.schema.yaml
@@ -32,6 +32,12 @@ enterprise_url:
   description: "GitHub API url (including /api/v3) of your GitHub Enterprise hostname."
   type: "string"
 
+deployment_environment:
+  description: "The enviroment for this StackStorm server."
+  type: "string"
+  required: true
+  default: "production"
+
 # You need to manullay put this into your config, as it's not
 # compatiable with the config schema.
 

--- a/packs/github/pack.yaml
+++ b/packs/github/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - github
   - git
   - scm
-version : 0.5
+version : 0.6.0
 author : st2-dev
 email : info@stackstorm.com

--- a/packs/github/rules/deploy_pack_on_deployment_event.yaml
+++ b/packs/github/rules/deploy_pack_on_deployment_event.yaml
@@ -1,7 +1,7 @@
 ---
-name: "deployment_event_webhook"
+name: "deploy_pack_on_deployment_event"
 pack: "github"
-description: "Trigger ST2 pack deploy when recieving a deployment event from GitHub."
+description: "Trigger an ST2 pack.install when receiving a deployment event from GitHub."
 enabled: false
 
 trigger:

--- a/packs/github/rules/deployment_event_webhook.yaml
+++ b/packs/github/rules/deployment_event_webhook.yaml
@@ -1,0 +1,29 @@
+---
+name: "deployment_event_webhook"
+pack: "github"
+description: "Trigger ST2 pack deploy when recieving a deployment event from GitHub."
+enabled: false
+
+trigger:
+  type: "core.st2.webhook"
+  parameters:
+    url: "github_deployment_event"
+
+criteria:
+  trigger.body:
+    pattern: "deployment"
+    type: "exists"
+
+action:
+  ref: "github.deployment_event"
+  parameters:
+    repo_fullname:  "{{trigger.body.repository.full_name}}"
+    repo_name:      "{{trigger.body.repository.name}}"
+    deploy_ref:     "{{trigger.body.deployment.ref}}"
+    deploy_env:     "{{trigger.body.deployment.environment}}"
+    deploy_sha:     "{{trigger.body.deployment.sha}}"
+    deploy_payload: "{{trigger.body.deployment.payload}}"
+    deploy_desc:    "{{trigger.body.deployment.description}}"
+    deploy_id:      "{{trigger.body.deployment.id}}"
+    ssh_url:        "{{trigger.body.repository.ssh_url}}"
+    creator:        "{{trigger.body.deployment.creator.login}}"

--- a/packs/github/tests/fixtures/full.yaml
+++ b/packs/github/tests/fixtures/full.yaml
@@ -2,3 +2,5 @@ enterprise_url: "https://github.exmple.com/api/v3"
 token: "foobar"
 
 default: "online"
+
+deployment_environment: "production"

--- a/packs/github/tests/test_action_check_deployment_env.py
+++ b/packs/github/tests/test_action_check_deployment_env.py
@@ -1,0 +1,36 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+# from mock import MagicMock
+
+from github_base_action_test_case import GitHubBaseActionTestCase
+
+from check_deployment_env import CheckDeploymentEnvAction
+
+
+class CheckDeploymentEnvActionTestCase(GitHubBaseActionTestCase):
+    __test__ = True
+    action_cls = CheckDeploymentEnvAction
+
+    def test_run_matching_env(self):
+        action = self.get_action_instance(self.full_config)
+        self.assertTrue(action.run("production"))
+
+    def test_run_non_matching_env(self):
+        action = self.get_action_instance(self.full_config)
+        self.assertRaises(ValueError,
+                          action.run,
+                          "staging")
+
+

--- a/packs/github/tests/test_action_check_deployment_env.py
+++ b/packs/github/tests/test_action_check_deployment_env.py
@@ -32,5 +32,3 @@ class CheckDeploymentEnvActionTestCase(GitHubBaseActionTestCase):
         self.assertRaises(ValueError,
                           action.run,
                           "staging")
-
-


### PR DESCRIPTION
## GitHub

### Status 

- Complete pack extension

### Description

Add to GitHub pack a webhook, workflow and extra action to process GitHub Deployment events to allow `packs.install` to be called when the enviroment matches that in the configuration. Following the running of `packs.install` GitHub is updated with the status of the deployment..

### Checklist (tick everything that applies)

- [X] Metadata: pack.yaml, icon, structure (required for new packs)
- [X] Version bump (required for changed packs)
- [X] Code linting (required, can be done after the PR checks)
- [X] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)