### PR TITLE
Added support for 2nd Generation HUE bridges

### DIFF
--- a/packs/hue/README.md
+++ b/packs/hue/README.md
@@ -8,12 +8,19 @@ This pack must be used on the same private network as the Hue bridge.
 ## Configuration
 
 * `station_ip` IP address or FQDN of Philips Hue Bridge
+* `client_identifier` API Key from the Philips Hue Bridge
 
 ## First Run
+
+### First Generation Hue Bridge
 
 The first run of any action will block until it is authorized. After
 installation, run the `hue.list_bulbs` and then press the button
 on your Hue device to authorize StackStorm.
+
+### Second Generation Hue Bridge
+
+Follow instructions at http://www.developers.meethue.com/documentation/getting-started to generate an API key to place in config.yaml
 
 ## Actions
 

--- a/packs/hue/README.md
+++ b/packs/hue/README.md
@@ -16,11 +16,13 @@ This pack must be used on the same private network as the Hue bridge.
 
 The first run of any action will block until it is authorized. After
 installation, run the `hue.list_bulbs` and then press the button
-on your Hue device to authorize StackStorm.
+on your Hue device to authorize StackStorm.  Alteratively, you can also
+generate the key manually using the instructions for 2nd Generation.
 
 ### Second Generation Hue Bridge
 
-Follow instructions at http://www.developers.meethue.com/documentation/getting-started to generate an API key to place in config.yaml
+Follow instructions at http://www.developers.meethue.com/documentation/getting-started 
+to generate an API key to place in config.yaml
 
 ## Actions
 

--- a/packs/hue/actions/lib/action.py
+++ b/packs/hue/actions/lib/action.py
@@ -10,6 +10,7 @@ class BaseAction(Action):
     def _get_client(self):
         hue = Hue()
         hue.station_ip = self.config['station_ip']
+        hue.client_identifier = self.config['client_identifier']
         hue.get_state()
 
         return hue

--- a/packs/hue/config.yaml
+++ b/packs/hue/config.yaml
@@ -1,2 +1,3 @@
 --- 
   station_ip: ""
+  client_identifier: ""

--- a/packs/hue/pack.yaml
+++ b/packs/hue/pack.yaml
@@ -2,7 +2,7 @@
 ---
 name: hue
 description: Philips Hue Pack
-version: 0.0.1
+version: 0.0.2
 author: James Fryman
 email: james@stackstorm.com
 keywords:


### PR DESCRIPTION
## Hue

### Status 

Bug Fix / Feature enhancement to support 2nd Generation Phillips HUE bridges

### Description

The Python-Hue library doesn't support the new authentication method used in the 2nd Generation Hue Bridge.  Easy work-around is to manually generate the API Key via the HUE Bridge WebGUI. Once configured in ST2, the library will use this key (if valid) and will not try to use 1st Generation authentication method.  The manual method will also work with 1st Generation. 

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [X] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)