### PR TITLE
Add config schema to hue pack

### DIFF
--- a/packs/hue/config.schema.yaml
+++ b/packs/hue/config.schema.yaml
@@ -1,0 +1,10 @@
+---
+  station_ip:
+    description: "IP address or FQDN of Philips Hue Bridge."
+    type: "string"
+    required: true
+  client_identifier:
+    description: "API Key from the Philips Hue Bridge."
+    type: "string"
+    secret: true
+    required: false

--- a/packs/hue/config.yaml
+++ b/packs/hue/config.yaml
@@ -1,3 +1,3 @@
---- 
+---
   station_ip: ""
   client_identifier: ""


### PR DESCRIPTION
This allows users to utilize new config schema functionality and configure API key as a secret in datastore (if desired).