### PR TITLE
Pack validation changes

### DIFF
--- a/packs/activecampaign/pack.yaml
+++ b/packs/activecampaign/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: activecampaign
 name: activecampaign
 author: DoriftoShoes
 description: 'Integration with ActiveCampaign'

--- a/packs/alertlogic/pack.yaml
+++ b/packs/alertlogic/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: alertlogic
 name: alertlogic
 description: AlertLogic ActiveIntegration APIs 
 keywords:

--- a/packs/ansible/pack.yaml
+++ b/packs/ansible/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: ansible
 name : ansible
 description : st2 content pack containing ansible integrations
 keywords:

--- a/packs/ansible/pack.yaml
+++ b/packs/ansible/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - ansible
   - cfg management
   - configuration management
-version : 0.3
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/ansible/pack.yaml
+++ b/packs/ansible/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - cfg management
   - configuration management
 version : 0.3
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: aws
 name : aws
 description : st2 content pack containing Amazon Web Services integrations.
 keywords:

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -18,5 +18,5 @@ keywords:
   - SQS
 
 version : 0.7.0
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/azure/pack.yaml
+++ b/packs/azure/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: azure
 name : azure
 description : st2 content pack containing Microsoft Azure integrations.
 keywords:

--- a/packs/azure/pack.yaml
+++ b/packs/azure/pack.yaml
@@ -9,6 +9,6 @@ keywords:
   - servers
   - virtual machines
   - azure virtual machines
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/azure/pack.yaml
+++ b/packs/azure/pack.yaml
@@ -10,5 +10,5 @@ keywords:
   - virtual machines
   - azure virtual machines
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/bitbucket/pack.yaml
+++ b/packs/bitbucket/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: bitbucket
 name: bitbucket
 description: Pack which allows integration with Bitbucket.
 keywords:

--- a/packs/bitcoin/pack.yaml
+++ b/packs/bitcoin/pack.yaml
@@ -4,5 +4,5 @@ description : bitcoin integration pack
 keywords:
   - bitcoin
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/bitcoin/pack.yaml
+++ b/packs/bitcoin/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: bitcoin
 name : bitcoin
 description : bitcoin integration pack
 keywords:

--- a/packs/bitcoin/pack.yaml
+++ b/packs/bitcoin/pack.yaml
@@ -3,6 +3,6 @@ name : bitcoin
 description : bitcoin integration pack
 keywords:
   - bitcoin
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/cassandra/pack.yaml
+++ b/packs/cassandra/pack.yaml
@@ -5,5 +5,5 @@ keywords:
   - datastax
   - cassandra
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/cassandra/pack.yaml
+++ b/packs/cassandra/pack.yaml
@@ -4,6 +4,6 @@ description : st2 content pack containing cassandra integrations
 keywords:
   - datastax
   - cassandra
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/cassandra/pack.yaml
+++ b/packs/cassandra/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: cassandra
 name : cassandra
 description : st2 content pack containing cassandra integrations
 keywords:

--- a/packs/check_mk/pack.yaml
+++ b/packs/check_mk/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: check_mk
 name: check_mk
 description: st2 content pack containing Check_MK integrations
 version: 0.1.0

--- a/packs/chef/pack.yaml
+++ b/packs/chef/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: chef
 name : chef
 description : st2 chef integration pack
 keywords:

--- a/packs/chef/pack.yaml
+++ b/packs/chef/pack.yaml
@@ -10,5 +10,5 @@ keywords:
   - configuration management
   - opscode
 version : 0.1.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/circle_ci/pack.yaml
+++ b/packs/circle_ci/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: circle_ci
 name: Circle CI
 description: Pack which allows integration with Circle CI.
 keywords:

--- a/packs/cisco_spark/pack.yaml
+++ b/packs/cisco_spark/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: cisco_spark
 name : cisco_spark
 description : cisco spark communication pack
 keywords:

--- a/packs/clicrud/pack.yaml
+++ b/packs/clicrud/pack.yaml
@@ -6,6 +6,6 @@ keywords :
   - mlx
   - cli
   - clicrud
-version : 0.1
+version : 0.1.0
 author : davidjohngee
 email : david.gee@ipengineer.net

--- a/packs/clicrud/pack.yaml
+++ b/packs/clicrud/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: clicrud
 name : clicrud
 description : CLICRUD integration for ST2
 keywords :

--- a/packs/cloudflare/pack.yaml
+++ b/packs/cloudflare/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: cloudflare
 name: cloudflare
 description: A pack to interact with the Cloudflare service.
 keywords:

--- a/packs/config_demo/pack.yaml
+++ b/packs/config_demo/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : config_demo
 description : Pack which demonstrated new pack configuration functionality available in StackStorm v1.5 and above.
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/config_demo/pack.yaml
+++ b/packs/config_demo/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: config_demo
 name : config_demo
 description : Pack which demonstrated new pack configuration functionality available in StackStorm v1.5 and above.
 version : 0.1.0

--- a/packs/config_demo/pack.yaml
+++ b/packs/config_demo/pack.yaml
@@ -2,5 +2,5 @@
 name : config_demo
 description : Pack which demonstrated new pack configuration functionality available in StackStorm v1.5 and above.
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/consul/pack.yaml
+++ b/packs/consul/pack.yaml
@@ -3,6 +3,6 @@
 ref: consul
 name: consul
 description: consul
-version: 0.0.1.0
+version: 0.1.0
 author: jfryman
 email: james@fryman.io

--- a/packs/consul/pack.yaml
+++ b/packs/consul/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: consul
 name: consul
 description: consul
 version: 0.0.1.0
 author: jfryman
 email: james@fryman.io
-

--- a/packs/consul/pack.yaml
+++ b/packs/consul/pack.yaml
@@ -2,7 +2,7 @@
 ---
 name: consul
 description: consul
-version: 0.0.1
+version: 0.0.1.0
 author: jfryman
 email: james@fryman.io
 

--- a/packs/csv/pack.yaml
+++ b/packs/csv/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: csv
 name : csv
 description : st2 content pack containing CSV integrations
 keywords:

--- a/packs/csv/pack.yaml
+++ b/packs/csv/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version : 0.2
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/csv/pack.yaml
+++ b/packs/csv/pack.yaml
@@ -7,5 +7,5 @@ keywords:
   - deserialization
   - text processing
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/cubesensors/pack.yaml
+++ b/packs/cubesensors/pack.yaml
@@ -8,6 +8,6 @@ keywords:
   - sensors
   - probes
   - home automation
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/cubesensors/pack.yaml
+++ b/packs/cubesensors/pack.yaml
@@ -9,5 +9,5 @@ keywords:
   - probes
   - home automation
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/cubesensors/pack.yaml
+++ b/packs/cubesensors/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: cubesensors
 name : cubesensors
 description : st2 content pack containing CubeSensors integrations
 keywords:

--- a/packs/datadog/pack.yaml
+++ b/packs/datadog/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: datadog
 name: datadog
 description: datadog
 keywords:

--- a/packs/device42/pack.yaml
+++ b/packs/device42/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: device42
 name: device42
 description: Device42 Actions for StackStorm
 version: 0.1.0

--- a/packs/digitalocean/pack.yaml
+++ b/packs/digitalocean/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: digitalocean
 name : Digital Ocean
 description : st2 content pack containing Digital Ocean integration.
 version : 0.1.0

--- a/packs/digitalocean/pack.yaml
+++ b/packs/digitalocean/pack.yaml
@@ -2,5 +2,5 @@
 name : Digital Ocean
 description : st2 content pack containing Digital Ocean integration.
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/digitalocean/pack.yaml
+++ b/packs/digitalocean/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : Digital Ocean
 description : st2 content pack containing Digital Ocean integration.
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/dimensiondata/pack.yaml
+++ b/packs/dimensiondata/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: dimensiondata
 name : dimensiondata
 description : st2 content pack containing Dimension Data Cloud integrations
 keywords:

--- a/packs/dimensiondata/pack.yaml
+++ b/packs/dimensiondata/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - cloud
   - load balancers
   - dimension data
-version : 0.1
+version : 0.1.0
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com

--- a/packs/docker/pack.yaml
+++ b/packs/docker/pack.yaml
@@ -6,6 +6,6 @@ keywords :
   - containers
   - virtualization
   - cgroups
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/docker/pack.yaml
+++ b/packs/docker/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: docker
 name : docker
 description : st2 content pack containing docker integrations
 keywords :

--- a/packs/docker/pack.yaml
+++ b/packs/docker/pack.yaml
@@ -7,5 +7,5 @@ keywords :
   - virtualization
   - cgroups
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/dripstat/pack.yaml
+++ b/packs/dripstat/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - java
   - monitoring
   - performance monitoring
-version: 0.0.1
+version: 0.1.0
 author: James Fryman
 email: james@fryman.io

--- a/packs/dripstat/pack.yaml
+++ b/packs/dripstat/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: dripstat
 name: dripstat
 description: Integration with the Dripstat Application Performance Monitoring tool
 keywords:

--- a/packs/duo/pack.yaml
+++ b/packs/duo/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: duo
 name: duo
 description: Use Duo 2FA authenication with StackStorm actions.
 keywords:

--- a/packs/elasticsearch/pack.yaml
+++ b/packs/elasticsearch/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: elasticsearch
 name : elasticsearch
 description : st2 elasticsearch integration pack
 keywords:

--- a/packs/elasticsearch/pack.yaml
+++ b/packs/elasticsearch/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - curator
   - databases
 version : 0.3.0
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/email/pack.yaml
+++ b/packs/email/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: email
 name: email
 description: E-Mail Actions/Sensors for StackStorm
 version: 0.1.0
 author: James Fryman
 email: james@stackstorm.com
-

--- a/packs/fireeye/pack.yaml
+++ b/packs/fireeye/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: fireeye
 name: fireeye
 description: FireEye CM Series Integration
 version: 0.1.0

--- a/packs/fpm/pack.yaml
+++ b/packs/fpm/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: fpm
 name: fpm
 description: fpm
 version: 0.1.0

--- a/packs/fpm/pack.yaml
+++ b/packs/fpm/pack.yaml
@@ -2,7 +2,6 @@
 ---
 name: fpm
 description: fpm
-version: 0.0.1
+version: 0.1.0
 author: jfryman
 email: jfryman@FryBook-2.local
-

--- a/packs/freight/pack.yaml
+++ b/packs/freight/pack.yaml
@@ -2,7 +2,6 @@
 ---
 name: freight
 description: freight
-version: 0.0.1
+version: 0.1.0
 author: James Fryman
 email: james@fryman.io
-

--- a/packs/freight/pack.yaml
+++ b/packs/freight/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: freight
 name: freight
 description: freight
 version: 0.1.0

--- a/packs/git/pack.yaml
+++ b/packs/git/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: git
 name : git
 description : st2 content pack containing git integrations
 keywords:

--- a/packs/git/pack.yaml
+++ b/packs/git/pack.yaml
@@ -5,5 +5,5 @@ keywords:
   - git
   - scm
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/git/pack.yaml
+++ b/packs/git/pack.yaml
@@ -4,6 +4,6 @@ description : st2 content pack containing git integrations
 keywords:
   - git
   - scm
-version : 0.2
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/github/pack.yaml
+++ b/packs/github/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: github
 name : github
 description : st2 content pack containing github integrations
 keywords:

--- a/packs/github/pack.yaml
+++ b/packs/github/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - git
   - scm
 version : 0.6.0
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/google/pack.yaml
+++ b/packs/google/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: google
 name : google
 description : st2 content pack containing google integrations
 keywords:

--- a/packs/google/pack.yaml
+++ b/packs/google/pack.yaml
@@ -5,5 +5,5 @@ keywords:
   - google
   - search
 version : 0.1.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/gpg/pack.yaml
+++ b/packs/gpg/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: gpg
 name: gpg
 description: Pack for working with GPG.
 keywords:

--- a/packs/gpg/pack.yaml
+++ b/packs/gpg/pack.yaml
@@ -9,5 +9,5 @@ keywords:
   - encryption
   - crypto
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/gpg/pack.yaml
+++ b/packs/gpg/pack.yaml
@@ -8,6 +8,6 @@ keywords:
   - privacy
   - encryption
   - crypto
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/hpe-icsp/pack.yaml
+++ b/packs/hpe-icsp/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: hpe-icsp
 name : hpe-icsp
 description : Pack for HP Enterprise Insight Control Server Provisioning Integration
 version : 0.3.1

--- a/packs/hubot/pack.yaml
+++ b/packs/hubot/pack.yaml
@@ -1,7 +1,7 @@
 ---
+ref: hubot
 name: hubot
 description: Hubot integration pack
 version: 0.1.0
 author: James Fryman
 email: james@stackstorm.com
-

--- a/packs/hue/pack.yaml
+++ b/packs/hue/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: hue
 name: hue
 description: Philips Hue Pack
 version: 0.0.2
@@ -9,4 +10,3 @@ keywords:
   - hue
   - philips
   - iot
-

--- a/packs/icinga2/pack.yaml
+++ b/packs/icinga2/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: icinga2
 name: icinga2
 description: Icinga2 Integration pack
 version: 0.2.0

--- a/packs/ipcam/pack.yaml
+++ b/packs/ipcam/pack.yaml
@@ -9,5 +9,5 @@ keywords:
   - smart home
   - home automation
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/ipcam/pack.yaml
+++ b/packs/ipcam/pack.yaml
@@ -8,6 +8,6 @@ keywords:
   - camera
   - smart home
   - home automation
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/ipcam/pack.yaml
+++ b/packs/ipcam/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: ipcam
 name : ipcam
 description : st2 content pack containing integration for various home IP cams
 keywords:

--- a/packs/irc/pack.yaml
+++ b/packs/irc/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: irc
 name : irc
 description : st2 content pack containing irc integrations
 keywords:

--- a/packs/irc/pack.yaml
+++ b/packs/irc/pack.yaml
@@ -8,5 +8,5 @@ keywords:
   - messaging
   - instant messaging
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/irc/pack.yaml
+++ b/packs/irc/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - chat
   - messaging
   - instant messaging
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/jenkins/pack.yaml
+++ b/packs/jenkins/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: jenkins
 name: jenkins
 description: Jenkins CI Integration Pack
 version: 0.1.0

--- a/packs/jira/pack.yaml
+++ b/packs/jira/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - ticket management
   - project management
 version : 0.3
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/jira/pack.yaml
+++ b/packs/jira/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - issues
   - ticket management
   - project management
-version : 0.3
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/jira/pack.yaml
+++ b/packs/jira/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: jira
 name : jira
 description : st2 content pack containing jira integrations
 keywords:

--- a/packs/jmx/pack.yaml
+++ b/packs/jmx/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: jmx
 name: jmx
 description: st2 content pack containing Java JMX integrations
 keywords:

--- a/packs/jmx/pack.yaml
+++ b/packs/jmx/pack.yaml
@@ -7,5 +7,5 @@ keywords:
   - java management extensions
   - mbean
 version: 0.1
-author: st2-dev
+author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/packs/jmx/pack.yaml
+++ b/packs/jmx/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - javajmx
   - java management extensions
   - mbean
-version: 0.1
+version: 0.1.0
 author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/packs/kubernetes/pack.yaml
+++ b/packs/kubernetes/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - kubenetes
   - sensors
   - thirdpartyresource
-version : 0.1
+version : 0.1.0
 author : Michael Ward
 email : mward29@gmail.com

--- a/packs/kubernetes/pack.yaml
+++ b/packs/kubernetes/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: kubernetes
 name : kubernetes
 description : st2 content pack containing Kubernetes sensors
 keywords:

--- a/packs/lastline/pack.yaml
+++ b/packs/lastline/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: lastline
 name: lastline
 description: Lastline Security Breach Detection Integration
 version: 0.1.0
 author: James Fryman
 email: james@stackstorm.com
-

--- a/packs/libcloud/pack.yaml
+++ b/packs/libcloud/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: libcloud
 name : libcloud
 description : st2 content pack containing libcloud integrations
 keywords:

--- a/packs/libcloud/pack.yaml
+++ b/packs/libcloud/pack.yaml
@@ -19,5 +19,5 @@ keywords:
   - gce
   - google compute engine
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/libcloud/pack.yaml
+++ b/packs/libcloud/pack.yaml
@@ -18,6 +18,6 @@ keywords:
   - cloudsigma
   - gce
   - google compute engine
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/librato/pack.yaml
+++ b/packs/librato/pack.yaml
@@ -2,7 +2,7 @@
 ---
 name: librato
 description: Send and manage metrics with Librato
-version: 0.0.1
+version: 0.0.1.0
 author: James Fryman
 email: james@fryman.io
 

--- a/packs/librato/pack.yaml
+++ b/packs/librato/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: librato
 name: librato
 description: Send and manage metrics with Librato
 version: 0.0.1.0
 author: James Fryman
 email: james@fryman.io
-

--- a/packs/librato/pack.yaml
+++ b/packs/librato/pack.yaml
@@ -3,6 +3,6 @@
 ref: librato
 name: librato
 description: Send and manage metrics with Librato
-version: 0.0.1.0
+version: 0.1.0
 author: James Fryman
 email: james@fryman.io

--- a/packs/mailgun/pack.yaml
+++ b/packs/mailgun/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - mail
   - mailgun
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/mailgun/pack.yaml
+++ b/packs/mailgun/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - email
   - mail
   - mailgun
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/mailgun/pack.yaml
+++ b/packs/mailgun/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: mailgun
 name : mailgun
 description : st2 content pack containing mailgun integrations
 keywords:

--- a/packs/mistral/pack.yaml
+++ b/packs/mistral/pack.yaml
@@ -4,6 +4,6 @@ description: Mistral integrations to operate mistral.
 keywords:
   - mistral
   - workflows
-version: 0.0.1
+version: 0.1.0
 author: StackStorm
 email: support@stackstorm.com

--- a/packs/mistral/pack.yaml
+++ b/packs/mistral/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: mistral
 name: mistral
 description: Mistral integrations to operate mistral.
 keywords:

--- a/packs/mmonit/pack.yaml
+++ b/packs/mmonit/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: mmonit
 name : mmonit
 description : st2 content pack containing mmonit integrations
 keywords:

--- a/packs/mmonit/pack.yaml
+++ b/packs/mmonit/pack.yaml
@@ -4,6 +4,6 @@ description : st2 content pack containing mmonit integrations
 keywords:
   - monitoring
   - mmonit
-version : 0.1
+version : 0.1.0
 author : Itxaka Serrano Garcia
 email : itxakaserrano@gmail.com

--- a/packs/mqtt/pack.yaml
+++ b/packs/mqtt/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: mqtt
 name: mqtt
 description: MQTT Integration for StackStorm
 version: 0.1.0

--- a/packs/mssql/pack.yaml
+++ b/packs/mssql/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: mssql
 name: mssql
 description: st2 content pack containing Microsoft SQL Server integrations
 keywords:

--- a/packs/nagios/pack.yaml
+++ b/packs/nagios/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: nagios
 name : nagios
 description : Nagios integration pack. See README.md for setup instructions.
 keywords:

--- a/packs/nagios/pack.yaml
+++ b/packs/nagios/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - monitoring
   - alerting
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/nagios/pack.yaml
+++ b/packs/nagios/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - nagios
   - monitoring
   - alerting
-version : 0.2
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/nest/pack.yaml
+++ b/packs/nest/pack.yaml
@@ -2,7 +2,7 @@
 ---
 name: nest
 description: StackStorm integration with Nest Thermostats
-version: 0.0.1
+version: 0.0.1.0
 author: James Fryman
 email: james@stackstorm.com
 

--- a/packs/nest/pack.yaml
+++ b/packs/nest/pack.yaml
@@ -3,6 +3,6 @@
 ref: nest
 name: nest
 description: StackStorm integration with Nest Thermostats
-version: 0.0.1.0
+version: 0.1.0
 author: James Fryman
 email: james@stackstorm.com

--- a/packs/nest/pack.yaml
+++ b/packs/nest/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: nest
 name: nest
 description: StackStorm integration with Nest Thermostats
 version: 0.0.1.0
 author: James Fryman
 email: james@stackstorm.com
-

--- a/packs/networking_utils/pack.yaml
+++ b/packs/networking_utils/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: networking_utils
 name: networking_utils
 description: A pack containing useful networking utils for use in workflows.
 keywords:

--- a/packs/networking_utils/pack.yaml
+++ b/packs/networking_utils/pack.yaml
@@ -6,6 +6,6 @@ keywords:
     - utilities
     - ipv4
     - ipv6
-version: 0.1
+version: 0.1.0
 author: Jon Middleton
 email: jon.middleton@pulsant.com

--- a/packs/newrelic/pack.yaml
+++ b/packs/newrelic/pack.yaml
@@ -7,5 +7,5 @@ keywords:
   - app monitoring
   - application level monitoring
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/newrelic/pack.yaml
+++ b/packs/newrelic/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - monitoring
   - app monitoring
   - application level monitoring
-version : 0.2
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/newrelic/pack.yaml
+++ b/packs/newrelic/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: newrelic
 name : newrelic
 description : st2 content pack containing newrelic integrations
 keywords:

--- a/packs/octopusdeploy/pack.yaml
+++ b/packs/octopusdeploy/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: octopusdeploy
 name : octopusdeploy
 description : st2 content pack containing octopusdeploy integrations
 keywords:

--- a/packs/octopusdeploy/pack.yaml
+++ b/packs/octopusdeploy/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - deployment
   - continous deployment
   - continous integration
-version : 0.1
+version : 0.1.0
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com

--- a/packs/openhab/pack.yaml
+++ b/packs/openhab/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: openhab
 name: openhab
 description: Integration with OpenHAB
 keywords:

--- a/packs/opscenter/pack.yaml
+++ b/packs/opscenter/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: opscenter
 name : opscenter
 description : st2 content pack containing datastax opscenter integrations
 keywords:

--- a/packs/opscenter/pack.yaml
+++ b/packs/opscenter/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - datastax
   - cassandra
   - opscenter
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/opscenter/pack.yaml
+++ b/packs/opscenter/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - cassandra
   - opscenter
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/opsgenie/pack.yaml
+++ b/packs/opsgenie/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: opsgenie
 name: opsgenie
 description: A intergration pack for the OpsGenie Service
 keywords:

--- a/packs/orion/pack.yaml
+++ b/packs/orion/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: orion
 name: orion
 description: Intergrate via the OrionSDK to SolarWinds Orion
 keywords:

--- a/packs/packagecloud/pack.yaml
+++ b/packs/packagecloud/pack.yaml
@@ -4,5 +4,5 @@ description : packagecloud integration pack
 keywords:
   - packagecloud
 version : 0.4
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/packagecloud/pack.yaml
+++ b/packs/packagecloud/pack.yaml
@@ -3,6 +3,6 @@ name : packagecloud
 description : packagecloud integration pack
 keywords:
   - packagecloud
-version : 0.4
+version : 0.4.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/packagecloud/pack.yaml
+++ b/packs/packagecloud/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: packagecloud
 name : packagecloud
 description : packagecloud integration pack
 keywords:

--- a/packs/packer/pack.yaml
+++ b/packs/packer/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: packer
 name: packer
 description: Hashicorp Packer builder integration
 version: 0.1.0

--- a/packs/pagerduty/pack.yaml
+++ b/packs/pagerduty/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: pagerduty
 name: pagerduty
 description: Packs which allows integration with PagerDuty services.
 version: 0.1.0

--- a/packs/powerpoint/pack.yaml
+++ b/packs/powerpoint/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: powerpoint
 name: powerpoint
 description: Packs which allows integration with Microsoft Powerpoint
 version: 0.1.0

--- a/packs/puppet/pack.yaml
+++ b/packs/puppet/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: puppet
 name : puppet
 description : st2 content pack containing puppet integrations
 keywords:

--- a/packs/puppet/pack.yaml
+++ b/packs/puppet/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - cfg management
   - configuration management
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/qualys/pack.yaml
+++ b/packs/qualys/pack.yaml
@@ -4,6 +4,6 @@ description : Qualys Cloud Security Services integration pack
 keywords:
   - security
   - qualys
-version : 1.0
+version : 1.0.0
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com

--- a/packs/qualys/pack.yaml
+++ b/packs/qualys/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: qualys
 name : qualys
 description : Qualys Cloud Security Services integration pack
 keywords:

--- a/packs/rabbitmq/pack.yaml
+++ b/packs/rabbitmq/pack.yaml
@@ -8,6 +8,6 @@ keywords:
   - aqmp
   - stomp
   - message broker
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/rabbitmq/pack.yaml
+++ b/packs/rabbitmq/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: rabbitmq
 name : rabbitmq
 description : st2 content pack containing rabbitmq integrations
 keywords:

--- a/packs/rabbitmq/pack.yaml
+++ b/packs/rabbitmq/pack.yaml
@@ -9,5 +9,5 @@ keywords:
   - stomp
   - message broker
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/rackspace/pack.yaml
+++ b/packs/rackspace/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: rackspace
 name: rackspace
 description: Packs which allows integration with Rackspace services such as servers, load balancers and DNS.
 version: 0.1.0

--- a/packs/reamaze/pack.yaml
+++ b/packs/reamaze/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: reamaze
 name: reamaze
 description: reamaze Integration Pack
 version: 0.1.1
 author: James Fryman
 email: james@stackstorm.com
-

--- a/packs/salt/pack.yaml
+++ b/packs/salt/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: salt
 name : salt
 description : st2 salt integration pack
 keywords:

--- a/packs/save_kittens/pack.yaml
+++ b/packs/save_kittens/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : save_kittens
 description : Save the world. One puzzle at a time.
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/save_kittens/pack.yaml
+++ b/packs/save_kittens/pack.yaml
@@ -2,5 +2,5 @@
 name : save_kittens
 description : Save the world. One puzzle at a time.
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/save_kittens/pack.yaml
+++ b/packs/save_kittens/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: save_kittens
 name : save_kittens
 description : Save the world. One puzzle at a time.
 version : 0.1.0

--- a/packs/sensu/pack.yaml
+++ b/packs/sensu/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - sensu
   - monitoring
   - alerting
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/sensu/pack.yaml
+++ b/packs/sensu/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - monitoring
   - alerting
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/sensu/pack.yaml
+++ b/packs/sensu/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: sensu
 name : sensu
 description : st2 content pack containing sensu integrations
 keywords:

--- a/packs/servicenow/pack.yaml
+++ b/packs/servicenow/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: servicenow
 name: servicenow
 description: ServiceNow Integration Pack
 version: 0.2.0

--- a/packs/signalr/pack.yaml
+++ b/packs/signalr/pack.yaml
@@ -4,6 +4,6 @@ description : st2 content pack containing signalr integrations
 keywords:
   - signalr
   - messaging
-version : 0.1
+version : 0.1.0
 author : Anthony Shaw
 email : anthony.shaw@dimensiondata.com

--- a/packs/signalr/pack.yaml
+++ b/packs/signalr/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: signalr
 name : signalr
 description : st2 content pack containing signalr integrations
 keywords:

--- a/packs/slack/pack.yaml
+++ b/packs/slack/pack.yaml
@@ -7,5 +7,5 @@ keywords:
   - messaging
   - instant messaging
 version : 0.2.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/slack/pack.yaml
+++ b/packs/slack/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: slack
 name : slack
 description : st2 content pack containing slack integrations
 keywords:

--- a/packs/smartthings/pack.yaml
+++ b/packs/smartthings/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: smartthings
 name: SmartThings
 description: Integration with SmartThings
 keywords:

--- a/packs/softlayer/pack.yaml
+++ b/packs/softlayer/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: softlayer
 name : softlayer
 description : st2 content pack containing Softlayer integrations.
 keywords:

--- a/packs/softlayer/pack.yaml
+++ b/packs/softlayer/pack.yaml
@@ -4,6 +4,6 @@ description : st2 content pack containing Softlayer integrations.
 keywords:
   - softlayer
   - cloud
-version : 0.1
+version : 0.1.0
 author : Itxaka Serrano Garcia
 email : itxakaserrano@gmail.com

--- a/packs/splunk/pack.yaml
+++ b/packs/splunk/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: splunk
 name: splunk
 description: Splunk integration pack
 keywords:

--- a/packs/splunk/pack.yaml
+++ b/packs/splunk/pack.yaml
@@ -3,6 +3,6 @@ name: splunk
 description: Splunk integration pack
 keywords:
   - splunk
-version : 0.2
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/splunk/pack.yaml
+++ b/packs/splunk/pack.yaml
@@ -4,5 +4,5 @@ description: Splunk integration pack
 keywords:
   - splunk
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/st2/pack.yaml
+++ b/packs/st2/pack.yaml
@@ -3,5 +3,5 @@
 name: st2
 description: StackStorm pack management
 version: 0.1.2
-author: st2-dev
+author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/packs/st2/pack.yaml
+++ b/packs/st2/pack.yaml
@@ -1,5 +1,6 @@
 ### Place information about your pack version here.
 ---
+ref: st2
 name: st2
 description: StackStorm pack management
 version: 0.1.2

--- a/packs/tesla/pack.yaml
+++ b/packs/tesla/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: tesla
 name : tesla
 description : car horn automation
 keywords:

--- a/packs/time/pack.yaml
+++ b/packs/time/pack.yaml
@@ -4,6 +4,6 @@ description: st2 content pack containing different date and time related functio
 keywords:
   - date
   - time
-version: 0.1
+version: 0.1.0
 author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/packs/time/pack.yaml
+++ b/packs/time/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: time
 name: time
 description: st2 content pack containing different date and time related functionality
 keywords:

--- a/packs/time/pack.yaml
+++ b/packs/time/pack.yaml
@@ -5,5 +5,5 @@ keywords:
   - date
   - time
 version: 0.1
-author: st2-dev
+author: StackStorm, Inc.
 email: info@stackstorm.com

--- a/packs/travis_ci/pack.yaml
+++ b/packs/travis_ci/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: travis_ci
 name: Travis CI
 description: Pack which allows integration with Travis CI.
 keywords:

--- a/packs/trello/pack.yaml
+++ b/packs/trello/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: trello
 name: trello
 description: Integration with Trello, Web based Project Management
 version: 0.2.0

--- a/packs/twilio/pack.yaml
+++ b/packs/twilio/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : twilio
 description : st2 content pack containing twilio integrations
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/twilio/pack.yaml
+++ b/packs/twilio/pack.yaml
@@ -2,5 +2,5 @@
 name : twilio
 description : st2 content pack containing twilio integrations
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/twilio/pack.yaml
+++ b/packs/twilio/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: twilio
 name : twilio
 description : st2 content pack containing twilio integrations
 version : 0.1.0

--- a/packs/twitter/pack.yaml
+++ b/packs/twitter/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - twitter
   - social media
   - social networks
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/twitter/pack.yaml
+++ b/packs/twitter/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: twitter
 name : twitter
 description : st2 content pack containing twitter integrations
 keywords:

--- a/packs/twitter/pack.yaml
+++ b/packs/twitter/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - social media
   - social networks
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/typeform/pack.yaml
+++ b/packs/typeform/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: typeform
 name : typeform
 description : Typeform service integration pack
 version : 0.2.0

--- a/packs/typeform/pack.yaml
+++ b/packs/typeform/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name : typeform
 description : Typeform service integration pack
-version : 0.2
+version : 0.2.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/typeform/pack.yaml
+++ b/packs/typeform/pack.yaml
@@ -2,5 +2,5 @@
 name : typeform
 description : Typeform service integration pack
 version : 0.2
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/urbandict/pack.yaml
+++ b/packs/urbandict/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: urbandict
 name : urbandict
 description : st2 content pack containing urban dictionary integrations
 keywords:

--- a/packs/urbandict/pack.yaml
+++ b/packs/urbandict/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - urban dict
   - urban dictionary
   - puns
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/urbandict/pack.yaml
+++ b/packs/urbandict/pack.yaml
@@ -6,5 +6,5 @@ keywords:
   - urban dictionary
   - puns
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/vadc/pack.yaml
+++ b/packs/vadc/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: vadc
 name : vadc
 description : Brocade vADC actions
 keywords:

--- a/packs/vadc/pack.yaml
+++ b/packs/vadc/pack.yaml
@@ -7,6 +7,6 @@ keywords:
   - vtm
   - bsd
   - loadbalancer
-version : 0.1
+version : 0.1.0
 author : mbodding
 email : mbodding@brocade.com

--- a/packs/vault/pack.yaml
+++ b/packs/vault/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: vault
 name: vault
 description: vault
 version: 0.0.1.0

--- a/packs/vault/pack.yaml
+++ b/packs/vault/pack.yaml
@@ -2,6 +2,6 @@
 ref: vault
 name: vault
 description: vault
-version: 0.0.1.0
+version: 0.1.0
 author: steve.neuharth
 email: steve.neuharth@target.com

--- a/packs/vault/pack.yaml
+++ b/packs/vault/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: vault
 description: vault
-version: 0.0.1
+version: 0.0.1.0
 author: steve.neuharth
 email: steve.neuharth@target.com

--- a/packs/vdx/pack.yaml
+++ b/packs/vdx/pack.yaml
@@ -2,5 +2,5 @@
 name: vdx
 description: Brocade VDX integration pack.
 version: 0.0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/vdx/pack.yaml
+++ b/packs/vdx/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: vdx
 name: vdx
 description: Brocade VDX integration pack.
 version: 0.0.1.0

--- a/packs/vdx/pack.yaml
+++ b/packs/vdx/pack.yaml
@@ -2,6 +2,6 @@
 ref: vdx
 name: vdx
 description: Brocade VDX integration pack.
-version: 0.0.1.0
+version: 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/vdx/pack.yaml
+++ b/packs/vdx/pack.yaml
@@ -1,6 +1,6 @@
 ---
 name: vdx
 description: Brocade VDX integration pack.
-version: 0.0.1
+version: 0.0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/victorops/pack.yaml
+++ b/packs/victorops/pack.yaml
@@ -1,3 +1,5 @@
+---
+ref: victorops
 name: victorops
 description: Packs which allows integration with Victorops events.
 keywords:
@@ -5,4 +7,4 @@ keywords:
   - open, ack and resolve incidents
 version: 0.1.0
 author: Aamir
-email: raza.aamir01@gmail.com                               
+email: raza.aamir01@gmail.com

--- a/packs/vsphere/pack.yaml
+++ b/packs/vsphere/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: vsphere
 name : vsphere 
 description : st2 content pack containing vsphere integrations.
 version : 0.4.3

--- a/packs/webpagetest/pack.yaml
+++ b/packs/webpagetest/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: webpagetest
 name: webpagetest
 description: st2 content pack containing webpagetest integrations
 keywords:

--- a/packs/webpagetest/pack.yaml
+++ b/packs/webpagetest/pack.yaml
@@ -4,6 +4,6 @@ description: st2 content pack containing webpagetest integrations
 keywords:
   - webpagetest
   - benchmarking
-version: 0.1
+version: 0.1.0
 author: Linuturk
 email: linuturk@onitato.com

--- a/packs/windows/pack.yaml
+++ b/packs/windows/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - wmi
   - windows management interface
   - wql
-version : 0.3
+version : 0.3.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/windows/pack.yaml
+++ b/packs/windows/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: windows
 name : windows
 description : st2 content pack containing windows integrations
 keywords:

--- a/packs/windows/pack.yaml
+++ b/packs/windows/pack.yaml
@@ -7,5 +7,5 @@ keywords:
   - windows management interface
   - wql
 version : 0.3
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/witai/pack.yaml
+++ b/packs/witai/pack.yaml
@@ -1,8 +1,8 @@
 ### Place information about your pack version here.
 ---
+ref: witai
 name: witai
 description: Wit AI Integration with StackStorm
 version: 0.1.0
 author: James Fryman
 email: james@stackstorm.com
-

--- a/packs/xml/pack.yaml
+++ b/packs/xml/pack.yaml
@@ -7,5 +7,5 @@ keywords:
   - deserialization
   - text processing
 version : 0.1
-author : st2-dev
+author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/xml/pack.yaml
+++ b/packs/xml/pack.yaml
@@ -6,6 +6,6 @@ keywords:
   - serialization
   - deserialization
   - text processing
-version : 0.1
+version : 0.1.0
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/xml/pack.yaml
+++ b/packs/xml/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: xml
 name : xml
 description : st2 content pack containing XML integrations
 keywords:

--- a/packs/yammer/pack.yaml
+++ b/packs/yammer/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: yammer
 name : yammer
 description : st2 content pack containing yammer integrations
 keywords:

--- a/packs/zendesk/pack.yaml
+++ b/packs/zendesk/pack.yaml
@@ -5,6 +5,6 @@ keywords:
   - zendesk
   - support
   - ticketing
-version : 0.1
+version : 0.1.0
 author : Casey Richardson
 email : casey@bluechasm.com

--- a/packs/zendesk/pack.yaml
+++ b/packs/zendesk/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: zendesk
 name : zendesk
 description : st2 content pack containing zendesk integrations
 keywords:

--- a/packs/zookeeper/pack.yaml
+++ b/packs/zookeeper/pack.yaml
@@ -1,4 +1,5 @@
 ---
+ref: zookeeper
 name: zookeeper
 description: st2 integration pack with zookeeper
 version: 0.1.0


### PR DESCRIPTION
This pull request updates pack metadata file so they will pass validation with new, to be released version of StackStorm.
## Background

Latest version of StackStorm changes some pack validation rules (version string now needs to be a valid `semver` identifier, email field needs to contain valid email address, etc.) and the pack.yaml is now also correctly validated the registration phase (previously there was a bug in the code so the pack metadata file wasn't actually validated).
## TODO
- [x] Add `ref` attribute with a value which matches directory name to each pack.yaml
