### PR TITLE
New actions for consul pack

### DIFF
--- a/packs/consul/actions/deregister_service.py
+++ b/packs/consul/actions/deregister_service.py
@@ -1,0 +1,8 @@
+from lib import action
+
+
+class ConsulDeregisterServiceAction(action.ConsulBaseAction):
+    def run(self, node, service, dc):
+
+        result = self.consul.catalog.deregister(node, service, dc=dc)
+        return (result, "")

--- a/packs/consul/actions/deregister_service.yaml
+++ b/packs/consul/actions/deregister_service.yaml
@@ -1,0 +1,20 @@
+name: deregister_service
+runner_type: run-python
+description: "De-Register an external service in Consul"
+enabled: true
+entry_point: "deregister_service.py"
+parameters:
+    node:
+        type: string
+        description: "Node Name/ID"
+        required: true
+        position: 0
+    service:
+        type: string
+        description: "Service Name/ID"
+        required: false
+        position: 1
+    dc:
+        type: string
+        description: "Optional Data Center ID"
+        required: false

--- a/packs/consul/actions/query_service.py
+++ b/packs/consul/actions/query_service.py
@@ -2,7 +2,10 @@ from lib import action
 
 
 class ConsulQueryServiceAction(action.ConsulBaseAction):
-    def run(self, service, tag=None):
+    def run(self, service, tag=None, ports=False):
         index, service = self.consul.catalog.service(service, tag=tag)
-        addresses = [node['Address'] for node in service]
+        if ports:
+            addresses = ["{}:{}".format(node['Address'],node['ServicePort']) for node in service]
+        else:
+            addresses = [node['Address'] for node in service]
         return ','.join(addresses)

--- a/packs/consul/actions/query_service.py
+++ b/packs/consul/actions/query_service.py
@@ -5,7 +5,7 @@ class ConsulQueryServiceAction(action.ConsulBaseAction):
     def run(self, service, tag=None, ports=False):
         index, service = self.consul.catalog.service(service, tag=tag)
         if ports:
-            addresses = ["{}:{}".format(node['Address'],node['ServicePort']) for node in service]
+            addresses = ["{}:{}".format(node['Address'], node['ServicePort']) for node in service]
         else:
             addresses = [node['Address'] for node in service]
         return ','.join(addresses)

--- a/packs/consul/actions/query_service.yaml
+++ b/packs/consul/actions/query_service.yaml
@@ -12,4 +12,10 @@ parameters:
     tag:
         type: string
         description: "Optional tags to query"
+        required: false
         position: 1
+    ports:
+        type: boolean
+        description: "Return port numbers in result"
+        required: false
+        position: 2

--- a/packs/consul/actions/register_service.py
+++ b/packs/consul/actions/register_service.py
@@ -2,8 +2,8 @@ from lib import action
 
 
 class ConsulRegisterServiceAction(action.ConsulBaseAction):
-    def run(self, nid, name, address, port, tags, dc):
+    def run(self, node, service, address, port, tags, dc):
 
-        definition = {"Service": name, "Port": port, "Tags": tags}
-        result = self.consul.catalog.register(nid, address, service=definition, dc=dc)
-        return result
+        definition = {"Service": service, "Port": port, "Tags": tags}
+        result = self.consul.catalog.register(node, address, service=definition, dc=dc)
+        return (result, "")

--- a/packs/consul/actions/register_service.py
+++ b/packs/consul/actions/register_service.py
@@ -4,6 +4,6 @@ from lib import action
 class ConsulRegisterServiceAction(action.ConsulBaseAction):
     def run(self, nid, name, address, port, tags, dc):
 
-        definition = { "Service": name, "Port": port, "Tags": tags }
+        definition = {"Service": name, "Port": port, "Tags": tags}
         result = self.consul.catalog.register(nid, address, service=definition, dc=dc)
         return result

--- a/packs/consul/actions/register_service.py
+++ b/packs/consul/actions/register_service.py
@@ -1,0 +1,9 @@
+from lib import action
+
+
+class ConsulRegisterServiceAction(action.ConsulBaseAction):
+    def run(self, nid, name, address, port, tags, dc):
+
+        definition = { "Service": name, "Port": port, "Tags": tags }
+        result = self.consul.catalog.register(nid, address, service=definition, dc=dc)
+        return result

--- a/packs/consul/actions/register_service.yaml
+++ b/packs/consul/actions/register_service.yaml
@@ -1,0 +1,34 @@
+name: register_service
+runner_type: run-python
+description: "Register an external service in Consul"
+enabled: true
+entry_point: "register_service.py"
+parameters:
+    nid:
+        type: string
+        description: "Node Name/ID"
+        required: true
+        position: 0
+    name:
+        type: string
+        description: "Service Name"
+        required: true
+        position: 1
+    address:
+        type: string
+        description: "IP Address of the service"
+        required: true
+        position: 2
+    port:
+        type: integer
+        description: "The Service Port"
+        required: true
+        position: 3
+    tags:
+        type: array
+        description: "Optional Array of Tags"
+        required: false
+    dc:
+        type: string
+        description: "Optional Data Center ID"
+        required: false

--- a/packs/consul/actions/register_service.yaml
+++ b/packs/consul/actions/register_service.yaml
@@ -4,14 +4,14 @@ description: "Register an external service in Consul"
 enabled: true
 entry_point: "register_service.py"
 parameters:
-    nid:
+    node:
         type: string
         description: "Node Name/ID"
         required: true
         position: 0
-    name:
+    service:
         type: string
-        description: "Service Name"
+        description: "Service Name/ID"
         required: true
         position: 1
     address:

--- a/packs/consul/pack.yaml
+++ b/packs/consul/pack.yaml
@@ -3,6 +3,6 @@
 ref: consul
 name: consul
 description: consul
-version: 0.1.0
+version: 0.2.0
 author: jfryman
 email: james@fryman.io

--- a/packs/vadc/sensors/brcd_sd_sensor.yaml
+++ b/packs/vadc/sensors/brcd_sd_sensor.yaml
@@ -3,6 +3,7 @@ class_name: "brcdSdSensor"
 entry_point: "brcd_sd_sensor.py"
 description: "Brocade Service Director Sensor"
 poll_interval: 30
+enabled: false
 trigger_types:
   -
     name: "bsd_failure_event"

--- a/packs/vadc/sensors/brcd_sd_sensor.yaml
+++ b/packs/vadc/sensors/brcd_sd_sensor.yaml
@@ -3,7 +3,6 @@ class_name: "brcdSdSensor"
 entry_point: "brcd_sd_sensor.py"
 description: "Brocade Service Director Sensor"
 poll_interval: 30
-enabled: false
 trigger_types:
   -
     name: "bsd_failure_event"


### PR DESCRIPTION
## Pack Consul

### Status 

Add actions to register and de-register external services, and also update the query_service action to return IPs and ports. 

- pack extension

### Description

query_service has an additional ports=<boolean> parameter, which defaults to false. When true, the returned list includes the port as ip:port.

New action: register_service can be used to register an external node/service with consul.
New action: deregister_service. Removes a registered node/service from consul.

### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
