### PR TITLE
add a dependent package to the requirements.txt in the aws pack (#611)

### DIFF
--- a/packs/aws/requirements.txt
+++ b/packs/aws/requirements.txt
@@ -2,3 +2,4 @@ six
 boto>=2.41.0,<2.42
 # Note: boto3 is used by the SQS sensor
 boto3>=1.3.1,<1.4
+flask>=0.10.1


### PR DESCRIPTION
## AWS

### Status 

- bugfix (#611)

### Description

Hi, 

A dependent module of `flask` doesn't exist in the requirements.txt of AWS pack.

This patch added it.  
The specified version number of `0.10.1` is then-current one when `flask` began to use.
(see also: https://github.com/pallets/flask/releases)

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [ ] Version bump (required for changed packs)
- [ ] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)

