### PR TITLE
Recursive get and list for Consul KV

### DIFF
--- a/packs/consul/CHANGES.md
+++ b/packs/consul/CHANGES.md
@@ -1,0 +1,17 @@
+# Change Log
+
+## 0.3.0
+
+ - Added consul.list action to get a list of Keys from consul under a given <root> key
+ - Added Recursive lookup for consul.get action.
+ - Both list and get use the same python runner with additional `recurse`, and `listing`
+   parameters with appropriate defaults.
+
+## 0.2.0
+
+ - Added ability to register and deregister a remote service with consul
+ - Added ports parameter to consul.query_service. When true, include ports in node list <ip:port>.
+
+## 0.1.0
+
+ - Initial Release

--- a/packs/consul/CHANGES.md
+++ b/packs/consul/CHANGES.md
@@ -4,7 +4,7 @@
 
  - Added consul.list action to get a list of Keys from consul under a given <root> key
  - Added Recursive lookup for consul.get action.
- - Both list and get use the same python runner with additional `recurse`, and `listing`
+ - Both list and get use the same python runner with additional `recurse`, and `keys`
    parameters with appropriate defaults.
 
 ## 0.2.0

--- a/packs/consul/actions/delete.py
+++ b/packs/consul/actions/delete.py
@@ -1,0 +1,6 @@
+from lib import action
+
+
+class ConsulDeleteAction(action.ConsulBaseAction):
+    def run(self, key, recurse):
+        return self.consul.kv.delete(key, recurse=recurse)

--- a/packs/consul/actions/delete.yaml
+++ b/packs/consul/actions/delete.yaml
@@ -1,0 +1,16 @@
+name: delete
+pack: consul
+runner_type: run-python
+description: "Delete value from Consul server"
+enabled: true
+entry_point: "delete.py"
+parameters:
+    key:
+        type: string
+        description: "Key to Delete from Consul"
+        required: true
+    recurse:
+        type: boolean
+        description: "Do a recursive deletion?"
+        required: false
+        default: false

--- a/packs/consul/actions/get.py
+++ b/packs/consul/actions/get.py
@@ -2,6 +2,6 @@ from lib import action
 
 
 class ConsulGetAction(action.ConsulBaseAction):
-    def run(self, key, recurse, listing):
-        list, value = self.consul.kv.get(key, recurse=recurse, keys=listing)
+    def run(self, key, recurse, keys):
+        list, value = self.consul.kv.get(key, recurse=recurse, keys=keys)
         return value

--- a/packs/consul/actions/get.py
+++ b/packs/consul/actions/get.py
@@ -2,6 +2,6 @@ from lib import action
 
 
 class ConsulGetAction(action.ConsulBaseAction):
-    def run(self, key):
-        list, value = self.consul.kv.get(key)
+    def run(self, key, recurse, listing):
+        list, value = self.consul.kv.get(key, recurse=recurse, keys=listing)
         return value

--- a/packs/consul/actions/get.yaml
+++ b/packs/consul/actions/get.yaml
@@ -13,7 +13,7 @@ parameters:
         description: "Do a recursive retrieval?"
         required: false
         default: false
-    listing:
+    keys:
         type: boolean
         description: "Return a list of keys only"
         required: false

--- a/packs/consul/actions/list.yaml
+++ b/packs/consul/actions/list.yaml
@@ -13,7 +13,7 @@ parameters:
         description: "Do a recursive retrieval?"
         required: false
         default: true
-    listing:
+    keys:
         type: boolean
         description: "Return a list of keys only"
         required: false

--- a/packs/consul/actions/list.yaml
+++ b/packs/consul/actions/list.yaml
@@ -1,21 +1,20 @@
-name: get
+name: list
 runner_type: run-python
-description: "Get value from Consul server"
+description: "List values from Consul server"
 enabled: true
 entry_point: "get.py"
 parameters:
     key:
         type: string
-        description: "Key to retrieve from Consul"
+        description: "Root Key for listing from Consul"
         required: true
     recurse:
         type: boolean
         description: "Do a recursive retrieval?"
         required: false
-        default: false
+        default: true
     listing:
         type: boolean
         description: "Return a list of keys only"
         required: false
-        default: false
-
+        default: true

--- a/packs/consul/pack.yaml
+++ b/packs/consul/pack.yaml
@@ -3,6 +3,6 @@
 ref: consul
 name: consul
 description: consul
-version: 0.2.0
+version: 0.3.0
 author: jfryman
 email: james@fryman.io


### PR DESCRIPTION
## Pack consul

### Status 

- pack extension

### Description

 - Added consul.list action to get a list of Keys from consul under a given <root> key
 - Added Recursive lookup for consul.get action.
 - Both list and get use the same python runner with additional `recurse`, and `listing`
   parameters with appropriate defaults.

### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)

