### PR TITLE
Support DNS round-robin balancing through Route53

### DIFF
--- a/packs/aws/actions/run.py
+++ b/packs/aws/actions/run.py
@@ -12,6 +12,8 @@ class ActionManager(action.BaseAction):
             kwargs['user_data'] = self.st2_user_data()
         if action == 'create_tags':
             kwargs['tags'] = self.split_tags(kwargs['tags'])
+        if action in ('add_a', 'update_a'):
+            kwargs['value'] = kwargs['value'].split(',')
         if 'cls' in kwargs.keys():
             cls = kwargs['cls']
             del kwargs['cls']

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -18,6 +18,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.7.0
+version : 0.7.1
 author : StackStorm, Inc.
 email : info@stackstorm.com


### PR DESCRIPTION
Our codegen actions for adding/updating A records in Route53 only support single IP as a value. This PR makes them accept a comma-separated list, which will add an unweighted round-robin A record with multiple IPs.

Should also add WRR at some point probably, but I don't care nearly enough to do that.