### PR TITLE
the correction of #623

### DIFF
--- a/packs/aws/actions/lib/ec2parsers.py
+++ b/packs/aws/actions/lib/ec2parsers.py
@@ -4,6 +4,7 @@ from boto import ec2
 from boto import route53
 from boto import cloudformation
 from boto import rds
+from boto import s3
 
 
 class FieldLists():
@@ -32,7 +33,6 @@ class FieldLists():
     ]
 
     BUCKET = [
-        'connection',
         'creation_date',
         'LoggingGroup',
         'name'
@@ -190,6 +190,8 @@ class ResultSets(object):
             return self.parseStackObject(output)
         elif isinstance(output, rds.dbinstance.DBInstance):
             return self.parseDBInstanceObject(output)
+        elif isinstance(output, s3.bucket.Bucket):
+            return self.parseBucket(output)
         else:
             return output
 

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -18,6 +18,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.7.0
+version : 0.7.1
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/aws/tests/aws_base_action_test_case.py
+++ b/packs/aws/tests/aws_base_action_test_case.py
@@ -1,0 +1,33 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import yaml
+
+from st2tests.base import BaseActionTestCase
+
+
+class AWSBaseActionTestCase(BaseActionTestCase):
+    __test__ = False
+
+    def setUp(self):
+        super(AWSBaseActionTestCase, self).setUp()
+
+        self._full_config = self.load_yaml('full.yaml')
+
+    def load_yaml(self, filename):
+        return yaml.safe_load(self.get_fixture_content(filename))
+
+    @property
+    def full_config(self):
+        return self._full_config

--- a/packs/aws/tests/fixtures/full.yaml
+++ b/packs/aws/tests/fixtures/full.yaml
@@ -1,0 +1,14 @@
+---
+aws_access_key_id: "access_key_id"
+aws_secret_access_key: "secret_key"
+region: "us-west-1"
+interval: 20
+st2_user_data: ""
+
+service_notifications_sensor:
+  host: "localhost"
+  port: 12345
+  path: "/my-path"
+
+sqs_sensor:
+  input_queues: "input_queue"

--- a/packs/aws/tests/test_action_get_bucket.py
+++ b/packs/aws/tests/test_action_get_bucket.py
@@ -1,0 +1,76 @@
+# Licensed to the StackStorm, Inc ('StackStorm') under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+
+import mock
+
+from aws_base_action_test_case import AWSBaseActionTestCase
+
+from boto.s3.connection import S3Connection
+from boto.s3.bucket import Bucket
+
+from run import ActionManager
+from datetime import datetime
+
+
+class MockBucket(Bucket):
+    def __init__(self, **kwargs):
+        super(MockBucket, self).__init__(**kwargs)
+
+        self.creation_date = datetime.now().isoformat()
+
+
+class GetBucketTestCase(AWSBaseActionTestCase):
+    __test__ = True
+    action_cls = ActionManager
+
+    _MOCK_BUCKETS = [
+        MockBucket(name='foo'),
+        MockBucket(name='bar'),
+    ]
+
+    def setUp(self):
+        super(GetBucketTestCase, self).setUp()
+
+        # default params of each actions
+        self._params = {
+            'headers': None,
+            'module_path': 'boto.s3.connection',
+            'cls': 'S3Connection',
+        }
+
+    @mock.patch.object(S3Connection, 'get_all_buckets',
+                       mock.MagicMock(return_value=_MOCK_BUCKETS))
+    def test_get_all_buckets(self):
+        self._params['action'] = 'get_all_buckets'
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self._params)
+
+        self.assertIsNotNone(result)
+        self.assertTrue(isinstance(result, list))
+        self.assertEqual(len(result), len(self._MOCK_BUCKETS))
+
+    @mock.patch.object(S3Connection, 'get_bucket',
+                       mock.MagicMock(return_value=MockBucket(name='foo')))
+    def test_get_bucket(self):
+        self._params['action'] = 'get_bucket'
+        self._params['validate'] = True
+
+        action = self.get_action_instance(self.full_config)
+        result = action.run(**self._params)
+
+        self.assertIsNotNone(result)
+        self.assertEqual(len(result), 1)
+        self.assertTrue(isinstance(result[0], dict))
+        self.assertEqual(result[0]['name'], 'foo')


### PR DESCRIPTION
## aws

### Status 

- bugfix

### Description
The main point of this correction is
* adding a condition to serialize s3.bucket.Bucket in the type selector.
* removing the `connection` field from returning Bucket object, because the `connection` field has a python object which is inherited `AWSAuthConnection`. If the returned result has python object, parse processing in the `PythonRunner` may fail. And the action result will be `None` as reported in #623.


### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [x] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
