### PR TITLE
flattened puppet config and moved to config.schema

### DIFF
--- a/packs/puppet/CHANGES.md
+++ b/packs/puppet/CHANGES.md
@@ -2,7 +2,15 @@
 
 ## v0.2.0
 
-Flattened configuration and migrated to config.schema.yaml
+**BREAKING CHANGE**
+
+The configuration in `config.yaml` has been flattened, and moved
+to `config.schema.yaml`. 
+
+Any older configuration will need to be updated. `hostname` and `port`
+are no longer subsections under `master` - they are now top-level
+configuration items. Similarly, `client_cert_path`, `client_cert_key_path`,
+`ca_cert_path` are now top-level items, not under `auth`.
 
 ## v0.1.0
 

--- a/packs/puppet/CHANGES.md
+++ b/packs/puppet/CHANGES.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v0.2.0
+
+Flattened configuration and migrated to config.schema.yaml
+
 ## v0.1.0
 
 * Initial release

--- a/packs/puppet/README.md
+++ b/packs/puppet/README.md
@@ -30,6 +30,16 @@ work by executing puppet CLI commands on the desired remote host.
 
 #### Configuration
 
+**BREAKING CHANGE**
+
+The configuration in `config.yaml` has been flattened, and moved
+to `config.schema.yaml`.
+
+Any older configurationis (< v0.2.0) will need to be updated. `hostname` and `port`
+are no longer subsections under `master` - they are now top-level
+configuration items. Similarly, `client_cert_path`, `client_cert_key_path`,
+`ca_cert_path` are now top-level items, not under `auth`.
+
 Copy the example configuration in [puppet.yaml.example](./puppet.yaml.example)
 to `/opt/stackstorm/configs/puppet.yaml` and edit as required.
 

--- a/packs/puppet/README.md
+++ b/packs/puppet/README.md
@@ -30,15 +30,17 @@ work by executing puppet CLI commands on the desired remote host.
 
 #### Configuration
 
-For the Python runner actions to work, you need to configure the following
-items in the config:
+Copy the example configuration in [puppet.yaml.example](./puppet.yaml.example)
+to `/opt/stackstorm/configs/puppet.yaml` and edit as required.
 
-* `master.hostname` - hostname of the puppet master
-* `master.port` - port of the puppet master
+* `hostname` - hostname of the puppet master
+* `port` - port of the puppet master
+* `client_cert_path` - path to the client certificate file used for authentication
+* `client_cert_key_path` - path to the private key file for the client certificate
+* `ca_cert_path` - path to the CA cert file
 
-* `auth.client_cert_path` - path to the client certificate file used for authentication
-* `auth.client_cert_key_path` - path to the private key file for the client certificate
-* `auth.ca_cert_path` - path to the CA cert file
+You can also use dynamic values from the datastore. See the
+[docs](https://docs.stackstorm.com/reference/pack_configs.html) for more info.
 
 Remote actions require no configuration. You simply need to specify server to
 run the action on when running the action (same as with other remote actions).

--- a/packs/puppet/actions/lib/python_actions.py
+++ b/packs/puppet/actions/lib/python_actions.py
@@ -9,13 +9,10 @@ class PuppetBasePythonAction(Action):
         self.client = self._get_client()
 
     def _get_client(self):
-        master_config = self.config['master']
-        auth_config = self.config['auth']
-
-        client = PuppetHTTPAPIClient(master_hostname=master_config['hostname'],
-                                     master_port=master_config['port'],
-                                     client_cert_path=auth_config['client_cert_path'],
-                                     client_cert_key_path=auth_config['client_cert_key_path'],
-                                     ca_cert_path=auth_config['ca_cert_path'])
+        client = PuppetHTTPAPIClient(master_hostname=self.config['hostname'],
+                                     master_port=self.config['port'],
+                                     client_cert_path=self.config['client_cert_path'],
+                                     client_cert_key_path=self.config['client_cert_key_path'],
+                                     ca_cert_path=self.config['ca_cert_path'])
 
         return client

--- a/packs/puppet/config.schema.yaml
+++ b/packs/puppet/config.schema.yaml
@@ -1,0 +1,27 @@
+---
+  hostname:
+    description: "Hostname of the Puppet master"
+    type: "string"
+    secret: false
+    required: true
+  port:
+    description: "Puppet API port"
+    type: "integer"
+    secret: false
+    required: true
+    default: 8140
+  client_cert_path:
+    description: "Path to the client certificate file used for authentication"
+    type: "string"
+    secret: false
+    required: true
+  client_cert_key_path:
+    description: "Path to the private key file used for the client certificate"
+    type: "string"
+    secret: false
+    required: true
+  ca_cert_path:
+    description: "Path to the CA cert file"
+    type: "string"
+    secret: false
+    required: true

--- a/packs/puppet/config.yaml
+++ b/packs/puppet/config.yaml
@@ -1,8 +1,0 @@
----
-  master:
-    hostname: "localhost"
-    port: 8140
-  auth:
-    client_cert_path: "/home/vagrant/.puppet/ssl/certs/host.pem"
-    client_cert_key_path: "/home/vagrant/.puppet/ssl/private_keys/host.pem"
-    ca_cert_path: "/home/vagrant/.puppet/ssl/ca/ca_crt.pem"

--- a/packs/puppet/puppet.yaml.example
+++ b/packs/puppet/puppet.yaml.example
@@ -1,0 +1,6 @@
+---
+hostname: "localhost"
+port: 8140
+client_cert_path: "/home/vagrant/.puppet/ssl/certs/host.pem"
+client_cert_key_path: "/home/vagrant/.puppet/ssl/private_keys/host.pem"
+ca_cert_path: "/home/vagrant/.puppet/ssl/ca/ca_crt.pem"


### PR DESCRIPTION
## Puppet

### Status 

- pack extension, complete

### Description

Flattened configuration and moved to `config.schema.yaml`. NB this will be breaking change for existing configs.

### Checklist (tick everything that applies)

- [X] Metadata: pack.yaml, icon, structure (required for new packs)
- [X] Version bump (required for changed packs)
- [X] Code linting (required, can be done after the PR checks)