### PR TITLE
correcting the problem which is mentioned in #629

### DIFF
--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -18,6 +18,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.7.1
+version : 0.7.2
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/aws/sensors/sqs_sensor.py
+++ b/packs/aws/sensors/sqs_sensor.py
@@ -82,13 +82,18 @@ class AWSSQSSensor(PollingSensor):
     def remove_trigger(self, trigger):
         pass
 
-    def _get_config_entry(self, key, prefix='setup'):
+    def _get_config_entry(self, key, prefix=None):
         ''' Get configuration values either from Datastore or config file. '''
-        config = self._config.get(prefix, None)
+        config = self.config
+        if prefix:
+            config = self._config.get(prefix, {})
 
         value = self._sensor_service.get_value('aws.%s' % (key), local=False)
         if not value:
             value = config.get(key, None)
+
+        if not value and config.get('setup', None):
+            value = config['setup'].get(key, None)
 
         if not value:
             raise ValueError('[AWSSQSSensor]: Configuration for %s key is missing.' % (key))

--- a/packs/aws/tests/fixtures/full.yaml
+++ b/packs/aws/tests/fixtures/full.yaml
@@ -12,3 +12,6 @@ service_notifications_sensor:
 
 sqs_sensor:
   input_queues: "input_queue"
+
+sqs_other:
+  max_number_of_messages: 1

--- a/packs/aws/tests/test_sensor_sqs.py
+++ b/packs/aws/tests/test_sensor_sqs.py
@@ -1,0 +1,61 @@
+import mock
+import yaml
+
+from st2tests.base import BaseSensorTestCase
+
+from sqs_sensor import AWSSQSSensor
+
+
+class MockQueue(object):
+    def __init__(self, msgs=[]):
+        self.dummy_messages = [MockMessage(x) for x in msgs]
+
+    def receive_messages(self, **kwargs):
+        return self.dummy_messages
+
+
+class MockMessage(object):
+    def __init__(self, body=None):
+        self.body = body
+
+    def delete(self):
+        return mock.MagicMock(return_value=None)
+
+
+class SQSSensorTestCase(BaseSensorTestCase):
+    sensor_cls = AWSSQSSensor
+
+    def setUp(self):
+        super(SQSSensorTestCase, self).setUp()
+
+        self.full_config = self.load_yaml('full.yaml')
+
+    def load_yaml(self, filename):
+        return yaml.safe_load(self.get_fixture_content(filename))
+
+    def test_poll_without_message(self):
+        sensor = self.get_sensor_instance(config=self.full_config)
+
+        sensor.setup()
+
+        # replace ServiceResource object to mock
+        sensor.sqs_res = mock.MagicMock()
+        sensor.sqs_res.get_queue_by_name = mock.MagicMock(return_value=MockQueue())
+
+        sensor.poll()
+
+        self.assertEqual(self.get_dispatched_triggers(), [])
+
+    def test_poll_with_message(self):
+        sensor = self.get_sensor_instance(config=self.full_config)
+
+        sensor.setup()
+
+        # replace ServiceResource object to mock
+        sensor.sqs_res = mock.MagicMock()
+        sensor.sqs_res.get_queue_by_name = mock.MagicMock(return_value=MockQueue(['foo']))
+
+        sensor.poll()
+
+        self.assertTriggerDispatched(trigger='aws.sqs_new_message')
+        self.assertNotEqual(self.get_dispatched_triggers(), [])


### PR DESCRIPTION
## aws

### Status
- bugfix

### Description

This patch add a processing to get values which are defined in top-level on the configuration.

In the past, the top-level parameters on the configuration (like `aws_access_*` and `region`) have never been referred. Instead, other params which are specified under the `setup` dictionary have been done.

This patch corrects to get these configuration parameters in the following order.

1. from the datastore
2. from configuration that is under the dictionary which is specified in `prefix` argument. 
3. from configuration that is under the `setup` directory for backwards compatibility.

This way enables to refer params which is define in arbitrary place as well as have backwards compatibility using the same interface.

Thank you.

### Checklist (tick everything that applies)

- [x] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [x] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
