### PR TITLE
Update event_types configuration option in the mmonit pack to use native platform type

### DIFF
--- a/packs/mmonit/CHANGES.md
+++ b/packs/mmonit/CHANGES.md
@@ -1,9 +1,14 @@
 # Change Log
 
+# 0.3.0
+
+- Change ``shared_sensors_config.event_types`` config option type from string to an array.
+  This way parameter utilizes native platform type.
+
 # 0.2.0
 
 - Rename `config.yaml` to `config.schema.yaml` and update to use schema.
 
 # 0.1.0
 
-- First release 
+- First release

--- a/packs/mmonit/config.schema.yaml
+++ b/packs/mmonit/config.schema.yaml
@@ -33,10 +33,14 @@
         type: "string"
         required: true
       event_types:
-        description: "Comma separated list of events to listen for. Possible values: 0=success, 1=error, 2=change. 1 and 2 by default"
-        type: "string"
+        description: "List of events to listen for. Possible values: 0=success, 1=error, 2=change. 1 and 2 by default"
+        type: "array"
+        items:
+          type: "string"
         required: true
-        default: "1,2"
+        default:
+          - "1"
+          - "2"
       active:
         description: "The active events filter. Possible values: 0=show all events, 1=show only active errors, 2=show only active errors but exclude user dismissed errors. Default 1."
         type: "integer"

--- a/packs/mmonit/mmonit.yaml.example
+++ b/packs/mmonit/mmonit.yaml.example
@@ -6,5 +6,7 @@ shared_sensors_config:
   host: ""
   username: ""
   password: ""
-  event_types: 1,2
+  event_types:
+    - "1"
+    - "2"
   active: 1

--- a/packs/mmonit/pack.yaml
+++ b/packs/mmonit/pack.yaml
@@ -5,6 +5,6 @@ description : st2 content pack containing mmonit integrations
 keywords:
   - monitoring
   - mmonit
-version : 0.2.0
+version : 0.3.0
 author : Itxaka Serrano Garcia
 email : itxakaserrano@gmail.com

--- a/packs/mmonit/sensors/events_sensor.py
+++ b/packs/mmonit/sensors/events_sensor.py
@@ -14,7 +14,7 @@ class MmonitEventsSensor(PollingSensor):
         self.user = self._config['shared_sensors_config']['username']
         self.password = self._config['shared_sensors_config']['password']
         self.active = self._config['shared_sensors_config']['active']
-        self.event_types = self._config['shared_sensors_config']['event_types'].split(',')
+        self.event_types = self._config['shared_sensors_config']['event_types']
         self.session = requests.session()
         self._login()
 


### PR DESCRIPTION
The title says it all.

We probably missed this during initial review.