### PR TITLE
python cannot find module bucket without the full path to Bucket

### DIFF
--- a/packs/aws/actions/lib/ec2parsers.py
+++ b/packs/aws/actions/lib/ec2parsers.py
@@ -4,8 +4,7 @@ from boto import ec2
 from boto import route53
 from boto import cloudformation
 from boto import rds
-from boto import s3
-
+from boto.s3.bucket import Bucket
 
 class FieldLists():
     ADDRESS = [
@@ -190,7 +189,7 @@ class ResultSets(object):
             return self.parseStackObject(output)
         elif isinstance(output, rds.dbinstance.DBInstance):
             return self.parseDBInstanceObject(output)
-        elif isinstance(output, s3.bucket.Bucket):
+        elif isinstance(output, Bucket):
             return self.parseBucket(output)
         else:
             return output

--- a/packs/aws/pack.yaml
+++ b/packs/aws/pack.yaml
@@ -18,6 +18,6 @@ keywords:
   - RDS
   - SQS
 
-version : 0.7.2
+version : 0.7.3
 author : StackStorm, Inc.
 email : info@stackstorm.com

--- a/packs/aws/requirements.txt
+++ b/packs/aws/requirements.txt
@@ -1,5 +1,5 @@
 six
-boto>=2.44.0,<2.45
+boto>=2.41.0,<2.42
 # Note: boto3 is used by the SQS sensor
 boto3>=1.3.1,<1.4
 flask>=0.10.1

--- a/packs/aws/requirements.txt
+++ b/packs/aws/requirements.txt
@@ -1,5 +1,5 @@
 six
-boto>=2.41.0,<2.42
+boto>=2.44.0,<2.45
 # Note: boto3 is used by the SQS sensor
 boto3>=1.3.1,<1.4
 flask>=0.10.1


### PR DESCRIPTION
## Pack AWS

### Status 

Replace this: describe the pack and PR status. Examples: 

- bugfix

### Description

Python 2.7 cannot import the s3.bucket module. Must import the entire path. s3.bucket.Bucket

### Checklist (tick everything that applies)

- [ ] Metadata: pack.yaml, icon, structure (required for new packs)
- [x] Version bump (required for changed packs)
- [x] Code linting (required, can be done after the PR checks)
- [ ] [Tests](https://docs.stackstorm.com/development/pack_testing.html) (not required but really recommended)
